### PR TITLE
LX-53 REST API improvements

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -2,12 +2,12 @@
 
 FROM python:3.6-alpine
 
-ENV VENV_PATH=/blockstore/venv
+ENV VIRTUAL_ENV=/blockstore/venv
 
 RUN apk update && apk upgrade
 RUN apk add bash bash-completion build-base git perl
 
-RUN python3.6 -m venv $VENV_PATH
+RUN python3.6 -m venv $VIRTUAL_ENV
 
 RUN echo 'cd /blockstore/app/' >> ~/.bashrc
-RUN echo 'export PATH=$VENV_PATH/bin:$PATH' >> ~/.bashrc
+RUN echo 'export PATH=$VIRTUAL_ENV/bin:$PATH' >> ~/.bashrc

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ help:
 	@perl -nle'print $& if m{^[\.a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}'
 	@echo ""
 
-VENV_PATH?=/blockstore/venv
+VENV_PATH?=$(or ${VIRTUAL_ENV},${VIRTUAL_ENV},/blockstore/venv)
 VENV_BIN=${VENV_PATH}/bin
 
 dev.up:

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ help:
 	@perl -nle'print $& if m{^[\.a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m  %-25s\033[0m %s\n", $$1, $$2}'
 	@echo ""
 
-VENV_PATH?=$(or ${VIRTUAL_ENV},${VIRTUAL_ENV},/blockstore/venv)
-VENV_BIN=${VENV_PATH}/bin
+VIRTUAL_ENV?=/blockstore/venv
+VENV_BIN=${VIRTUAL_ENV}/bin
 
 dev.up:
 	docker-compose --project-name blockstore -f docker-compose.yml up -d

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ clean: ## Remove all generated files
 requirements: ## Install requirements for development
 	${VENV_BIN}/pip install -qr requirements/local.txt --exists-action w
 
+requirements-test: ## Install requirements for testing
+	${VENV_BIN}/pip install -qr requirements/test.txt --exists-action w
+
 migrate:  ## Apply database migrations
 	${VENV_BIN}/python manage.py migrate --no-input
 

--- a/blockstore/apps/api/tests/test_utils.py
+++ b/blockstore/apps/api/tests/test_utils.py
@@ -1,0 +1,37 @@
+"""
+Tests for the blockstore API utils.
+"""
+
+import ddt
+from django.test import TestCase
+
+from ..utils import ZippableMultiValueDict
+
+
+@ddt.ddt
+class ZippableMultiValueDictTestCase(TestCase):
+    @ddt.data(
+        ({
+            'data': ['text file', '<html>file</html>'],
+            'path': ['c/file-4.txt', 'c/file-5.html'],
+            'public': [True, False]
+         },
+         [
+            {'data': 'text file', 'path': 'c/file-4.txt', 'public': True},
+            {'data': '<html>file</html>', 'path': 'c/file-5.html', 'public': False},
+         ]),
+        ({
+            'data': ['text file', '<html>file</html>'],
+            'path': [None, 'c/file-5.html'],
+            'public': [False]
+         },
+         [
+            {'data': 'text file', 'path': None, 'public': False},
+            {'data': '<html>file</html>', 'path': 'c/file-5.html'},
+         ]),
+    )
+    @ddt.unpack
+    def test_flatten(self, mvd, expected):
+        zippable = ZippableMultiValueDict(mvd)
+        zipped = zippable.zip()
+        assert zipped == expected

--- a/blockstore/apps/api/utils.py
+++ b/blockstore/apps/api/utils.py
@@ -1,0 +1,20 @@
+"""
+Utility functions for the Blockstore API.
+"""
+
+from django.utils.datastructures import MultiValueDict
+
+
+class ZippableMultiValueDict(MultiValueDict):
+
+    def zip(self):
+        """
+        Returns a list of dicts using the keys and values lists.
+        """
+        zipped = []
+        for key in self.keys():
+            for idx, value in enumerate(self.getlist(key)):
+                if len(zipped) <= idx:
+                    zipped.append({})
+                zipped[idx][key] = value
+        return zipped

--- a/blockstore/apps/api/utils.py
+++ b/blockstore/apps/api/utils.py
@@ -6,10 +6,63 @@ from django.utils.datastructures import MultiValueDict
 
 
 class ZippableMultiValueDict(MultiValueDict):
+    """
+    Enhances the MultiValueDict data structure to allow the grouping of multiple related values.
 
+    For example, consider the following querystring which might add multiple people to a dataset:
+        http://localhost?name=Abby&age=12&goal=astronaut&name=Bobby&age=14&name=Catherine&ambition=heiress
+
+    When this request is parsed, the resulting MultiValueDict will look like this:
+        {
+            'name': ['Abby', 'Bobby', 'Catherine'],
+            'age': [12, 14],
+            'ambition': ['astronaut', 'heiress'],
+        }
+
+    But really, we want each of these fields to be associated with a single person.  This is achieved with the `zip`
+    function added by this class.  The fields are collected in order, and missing values are not provided in the
+    resulting dicts.  E.g.,
+        [
+            {
+                'name': 'Abby',
+                'age': 12,
+                'ambition': 'astronaut',
+            },
+            {
+                'name': 'Bobby',
+                'age': 14,
+                'ambition': 'heiress',
+            },
+            {
+                'name': 'Catherine',
+            },
+        ]
+
+    Note that to maintain the alignment implied by the original querystring, we need to use a placeholder:
+
+        http://localhost?name=Abby&age=12&goal=astronaut&name=Bobby&age=14&ambition=&name=Catherine&ambition=heiress
+
+    Resulting in this MultiValueDict.zip():
+        [
+            {
+                'name': 'Abby',
+                'age': 12,
+                'ambition': 'astronaut',
+            },
+            {
+                'name': 'Bobby',
+                'age': 14,
+            },
+            {
+                'name': 'Catherine',
+                'ambition': 'heiress',
+            },
+        ]
+
+    """
     def zip(self):
         """
-        Returns a list of dicts using the keys and values lists.
+        Returns a list of dicts created by collecting the keys and values lists in the order received.
         """
         zipped = []
         for key in self.keys():

--- a/blockstore/apps/api/v1/serializers/bundles.py
+++ b/blockstore/apps/api/v1/serializers/bundles.py
@@ -3,11 +3,14 @@ Serializers for Bundles and BundleVersions.
 """
 
 from rest_framework import serializers
+from expander import ExpanderSerializerMixin
+
 from blockstore.apps.bundles.models import Bundle, BundleVersion, Collection
 from ... import relations
+from .snapshots import ExpandedFileInfoField
 
 
-class BundleSerializer(serializers.ModelSerializer):
+class BundleSerializer(ExpanderSerializerMixin, serializers.ModelSerializer):
     """
     Serializer for the Bundle model.
     """
@@ -26,6 +29,11 @@ class BundleSerializer(serializers.ModelSerializer):
             'uuid',
             'versions',
         )
+        expandable_fields = {
+            'files': (ExpandedFileInfoField, (), dict(
+                view_name='api:v1:bundlefile-detail',
+            ))
+        }
 
     collection = relations.HyperlinkedRelatedField(
         lookup_field='uuid',
@@ -55,7 +63,7 @@ class BundleSerializer(serializers.ModelSerializer):
     )
 
 
-class BundleVersionSerializer(serializers.ModelSerializer):
+class BundleVersionSerializer(ExpanderSerializerMixin, serializers.ModelSerializer):
     """
     Serializer for the BundleVersion model.
     """
@@ -71,6 +79,11 @@ class BundleVersionSerializer(serializers.ModelSerializer):
             'url',
             'version_num',
         )
+        expandable_fields = {
+            'files': (ExpandedFileInfoField, (), dict(
+                view_name='api:v1:bundleversionfile-detail',
+            ))
+        }
 
     bundle = relations.HyperlinkedRelatedField(
         lookup_field='uuid',

--- a/blockstore/apps/api/v1/serializers/bundles.py
+++ b/blockstore/apps/api/v1/serializers/bundles.py
@@ -3,14 +3,13 @@ Serializers for Bundles and BundleVersions.
 """
 
 from rest_framework import serializers
-from expander import ExpanderSerializerMixin
 
 from blockstore.apps.bundles.models import Bundle, BundleVersion, Collection
 from ... import relations
-from .snapshots import ExpandedFileInfoField
+from .snapshots import ExpandedFileInfoField, SingleExpanderSerializerMixin
 
 
-class BundleSerializer(ExpanderSerializerMixin, serializers.ModelSerializer):
+class BundleSerializer(SingleExpanderSerializerMixin, serializers.ModelSerializer):
     """
     Serializer for the Bundle model.
     """
@@ -63,7 +62,7 @@ class BundleSerializer(ExpanderSerializerMixin, serializers.ModelSerializer):
     )
 
 
-class BundleVersionSerializer(ExpanderSerializerMixin, serializers.ModelSerializer):
+class BundleVersionSerializer(SingleExpanderSerializerMixin, serializers.ModelSerializer):
     """
     Serializer for the BundleVersion model.
     """

--- a/blockstore/apps/api/v1/serializers/snapshots.py
+++ b/blockstore/apps/api/v1/serializers/snapshots.py
@@ -49,7 +49,7 @@ class FileInfoSerializer(serializers.Serializer):
 
     data = FileDataField()
     path = serializers.CharField()
-    public = serializers.BooleanField()
+    public = serializers.BooleanField(default=False)
     size = serializers.IntegerField(read_only=True)
 
     url = FileHyperlinkedIdentityField(

--- a/blockstore/apps/api/v1/serializers/snapshots.py
+++ b/blockstore/apps/api/v1/serializers/snapshots.py
@@ -74,7 +74,8 @@ class ExpandedFileInfoField(serializers.SerializerMethodField):
         assert view_name is not None, 'The `view_name` argument is required.'
         self.view_name = view_name
 
-        # Ignore the context argument if passed from the ExpanderSerializerMixin
+        # Ignore the context argument if passed from the ExpanderSerializerMixin, to prevent
+        # TypeError on super __init__: got an unexpected keyword argument 'context'
         kwargs.pop('context', None)
 
         super().__init__(*args, **kwargs)
@@ -112,6 +113,7 @@ class ExpandedFileInfoField(serializers.SerializerMethodField):
         if isinstance(instance, BundleVersion):
             bundle_version = instance
         else:
+            # instance is a Bundle: use its most recent BundleVersion
             bundle_version = instance.get_bundle_version()
 
         return bundle_version.snapshot().files.values()

--- a/blockstore/apps/api/v1/serializers/snapshots.py
+++ b/blockstore/apps/api/v1/serializers/snapshots.py
@@ -4,6 +4,7 @@ Serializers for Snapshots.
 
 from django.core.files.storage import default_storage
 from rest_framework import serializers
+from expander import ExpanderSerializerMixin
 
 from blockstore.apps.bundles.models import BundleVersion
 from ... import relations
@@ -68,7 +69,7 @@ class ExpandedFileInfoField(serializers.SerializerMethodField):
 
     def __init__(self, view_name, *args, **kwargs):
         """
-        Initialize the ExpandedFileInfoSerializer.
+        Initialize the ExpandedFileInfoField.
         """
         assert view_name is not None, 'The `view_name` argument is required.'
         self.view_name = view_name
@@ -114,3 +115,17 @@ class ExpandedFileInfoField(serializers.SerializerMethodField):
             bundle_version = instance.get_bundle_version()
 
         return bundle_version.snapshot().files.values()
+
+
+class SingleExpanderSerializerMixin(ExpanderSerializerMixin):
+    """
+    Allows configured fields to be expanded only if serializing a single object.
+    """
+
+    @classmethod
+    def many_init(cls, *args, **kwargs):
+        """
+        Disable requests for expanded fields when serializing a list of objects.
+        """
+        kwargs['expanded_fields'] = 'none'
+        return super().many_init(*args, **kwargs)

--- a/blockstore/apps/api/v1/tests/test_serializers.py
+++ b/blockstore/apps/api/v1/tests/test_serializers.py
@@ -13,12 +13,13 @@ from ..serializers.snapshots import FileInfoSerializer
 
 
 class SerializerBaseTestCase(TestCase):
+    """
+    Base class for serializer tests.
+    """
 
     def setUp(self):
 
         super().setUp()
-
-        self.request_factory = APIRequestFactory()
 
         self.collection = CollectionFactory(title="Collection 1")
 
@@ -36,13 +37,22 @@ class SerializerBaseTestCase(TestCase):
             version_num=1,
         )
 
+        self.request = APIRequestFactory().get('/')
+        self.request.query_params = {}
+        self.context = {
+            'request': self.request
+        }
+
 
 class BundleSerializerTestCase(SerializerBaseTestCase):
+    """
+    Tests for the BundleSerializer
+    """
 
     def test_bundle_serializer_data(self):
 
         bundle_serializer = BundleSerializer(
-            self.bundle, context={'request': self.request_factory.get('/')}
+            self.bundle, context=self.context,
         )
 
         self.assertSequenceEqual(list(bundle_serializer.data.keys()), [
@@ -60,11 +70,13 @@ class BundleSerializerTestCase(SerializerBaseTestCase):
 
 
 class BundleVersionSerializerTestCase(SerializerBaseTestCase):
-
+    """
+    Tests for the BundleVersionSerializer
+    """
     def test_bundle_version_serializer_data(self):
 
         bundle_version_serializer = BundleVersionSerializer(
-            self.bundle_version, context={'request': self.request_factory.get('/')}
+            self.bundle_version, context=self.context,
         )
 
         self.assertSequenceEqual(list(bundle_version_serializer.data.keys()), [
@@ -86,11 +98,14 @@ class BundleVersionSerializerTestCase(SerializerBaseTestCase):
 
 
 class CollectionSerializerTestCase(SerializerBaseTestCase):
+    """
+    Tests for the CollectionSerializer
+    """
 
     def test_collection_serializer_data(self):
 
         collection_serializer = CollectionSerializer(
-            self.collection, context={'request': self.request_factory.get('/')}
+            self.collection, context=self.context,
         )
 
         self.assertSequenceEqual(list(collection_serializer.data.keys()), [
@@ -104,23 +119,28 @@ class CollectionSerializerTestCase(SerializerBaseTestCase):
 
 
 class FileInfoSerializerTestCase(SerializerBaseTestCase):
+    """
+    Tests for the FileInfoSerializer
+    """
+    def setUp(self):
 
-    def test_file_info_serializer_data(self):
-        # pylint: disable=unsubscriptable-object
+        super().setUp()
 
-        request = self.request_factory.get('/')
-        request.parser_context = {
+        self.request.parser_context = {
             'kwargs': {
                 'bundle_uuid': self.bundle.uuid,
             }
         }
+
+    def test_file_info_serializer_data(self):
+        # pylint: disable=unsubscriptable-object
 
         file_info = FileInfoFactory(
             path='a/file.txt', public=False, size=100, hash_digest=bytes('hash_digest', 'utf-8')
         )
 
         file_info_serializer = FileInfoSerializer(
-            file_info, context={'request': request}
+            file_info, context=self.context,
         )
 
         self.assertSequenceEqual(list(file_info_serializer.data.keys()), [  # pylint: disable=no-member

--- a/blockstore/apps/api/v1/views/bundles.py
+++ b/blockstore/apps/api/v1/views/bundles.py
@@ -2,7 +2,7 @@
 Views for Bundles and BundleVersions.
 """
 
-from rest_framework import viewsets
+from rest_framework import viewsets, mixins
 from rest_framework.generics import get_object_or_404
 
 from blockstore.apps.bundles.models import Bundle, BundleVersion
@@ -24,7 +24,7 @@ class BundleViewSet(viewsets.ModelViewSet):
     serializer_class = BundleSerializer
 
 
-class BundleVersionViewSet(viewsets.ReadOnlyModelViewSet):
+class BundleVersionViewSet(mixins.UpdateModelMixin, viewsets.ReadOnlyModelViewSet):
     """
     ViewSet for BundleVersion model.
     """

--- a/blockstore/apps/api/v1/views/bundles.py
+++ b/blockstore/apps/api/v1/views/bundles.py
@@ -2,6 +2,7 @@
 Views for Bundles and BundleVersions.
 """
 
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets, mixins
 from rest_framework.generics import get_object_or_404
 
@@ -20,6 +21,9 @@ class BundleViewSet(viewsets.ModelViewSet):
     lookup_url_kwarg = 'bundle_uuid'
     lookup_value_regex = UUID4_REGEX
 
+    filter_backends = (DjangoFilterBackend,)
+    filterset_fields = ('collection__uuid',)
+
     queryset = Bundle.objects.all()
     serializer_class = BundleSerializer
 
@@ -32,6 +36,9 @@ class BundleVersionViewSet(mixins.UpdateModelMixin, viewsets.ReadOnlyModelViewSe
     lookup_fields = ('bundle__uuid', 'version_num')
     lookup_url_kwargs = ('bundle_uuid', 'version_num')
     lookup_value_regexes = (UUID4_REGEX, VERSION_NUM_REGEX)
+
+    filter_backends = (DjangoFilterBackend,)
+    filterset_fields = ('bundle__uuid',)
 
     queryset = BundleVersion.objects.all()
     serializer_class = BundleVersionSerializer

--- a/blockstore/apps/api/v1/views/bundles.py
+++ b/blockstore/apps/api/v1/views/bundles.py
@@ -38,7 +38,7 @@ class BundleVersionViewSet(mixins.UpdateModelMixin, viewsets.ReadOnlyModelViewSe
     lookup_value_regexes = (UUID4_REGEX, VERSION_NUM_REGEX)
 
     filter_backends = (DjangoFilterBackend,)
-    filterset_fields = ('bundle__uuid',)
+    filterset_fields = ('bundle__uuid', 'bundle__collection__uuid')
 
     queryset = BundleVersion.objects.all()
     serializer_class = BundleVersionSerializer

--- a/blockstore/apps/api/v1/views/snapshots.py
+++ b/blockstore/apps/api/v1/views/snapshots.py
@@ -34,23 +34,8 @@ class BundleFileReadOnlyViewSet(viewsets.ViewSet):
             'request': self.request,
         }
 
-    def get_bundle_version(self, bundle_uuid, version_num=None):
-        """ Get the bundle version. """
-
-        filter_kwargs = {
-            'bundle__uuid': bundle_uuid
-        }
-        if version_num:
-            filter_kwargs['version_num'] = version_num
-
-        try:
-            return BundleVersion.objects.filter(**filter_kwargs).order_by('-version_num').first()
-        except BundleVersion.DoesNotExist:
-            pass
-        return None
-
     def get_bundle_version_or_404(self, bundle_uuid, version_num=None):
-        bundle_version = self.get_bundle_version(bundle_uuid, version_num)
+        bundle_version = BundleVersion.get_bundle_version(bundle_uuid, version_num)
         if bundle_version:
             return bundle_version
         raise http.Http404
@@ -100,7 +85,7 @@ class BundleFileViewSet(BundleFileReadOnlyViewSet):
         if errors or not serializer_data:
             return Response(errors, status=status.HTTP_400_BAD_REQUEST)
 
-        bundle_version = self.get_bundle_version(bundle_uuid, version_num)
+        bundle_version = BundleVersion.get_bundle_version(bundle_uuid, version_num)
         if bundle_version:
             snapshot = bundle_version.snapshot()
         else:

--- a/blockstore/apps/api/v1/views/snapshots.py
+++ b/blockstore/apps/api/v1/views/snapshots.py
@@ -11,6 +11,7 @@ from blockstore.apps.bundles.store import BundleDataStore, BundleSnapshot
 from blockstore.apps.bundles.models import BundleVersion
 
 from ...constants import FILE_PATH_REGEX
+from ...utils import ZippableMultiValueDict
 from ..serializers.snapshots import FileInfoSerializer
 
 
@@ -85,26 +86,47 @@ class BundleFileViewSet(BundleFileReadOnlyViewSet):
     detail_view_name = 'api:v1:bundlefile-detail'
 
     def create(self, request, bundle_uuid, version_num=None):
-        """ Add file to a bundle. """
-        serializer = FileInfoSerializer(data=request.data)
-        if serializer.is_valid():
-            bundle_version = self.get_bundle_version(bundle_uuid, version_num)
-
-            if bundle_version:
-                snapshot = bundle_version.snapshot()
+        """ Add file(s) to a bundle. """
+        serializer_data = []
+        errors = []
+        request_data = ZippableMultiValueDict(request.data)
+        for fileinfo in request_data.zip():
+            serializer = FileInfoSerializer(data=fileinfo)
+            if serializer.is_valid():
+                serializer_data.append(serializer.validated_data)
             else:
-                snapshot = BundleSnapshot.create(bundle_uuid, {})
+                errors.append(serializer.errors)
 
-            store = BundleDataStore()
-            snapshot = store.snapshot_by_adding_path(snapshot, **serializer.validated_data)
+        if errors or not serializer_data:
+            return Response(errors, status=status.HTTP_400_BAD_REQUEST)
 
+        bundle_version = self.get_bundle_version(bundle_uuid, version_num)
+        if bundle_version:
+            snapshot = bundle_version.snapshot()
+        else:
+            snapshot = BundleSnapshot.create(bundle_uuid, {})
+
+        store = BundleDataStore()
+        snapshot = store.snapshot_by_adding_paths(
+            snapshot,
+            paths_to_files=serializer_data,
+        )
+
+        if len(serializer_data) == 1:
+            # Just return a single snapshot file if only one was added
+            validated_data = serializer_data[0]
             response_serializer = FileInfoSerializer(
-                snapshot.files[serializer.validated_data['path']],  # pylint: disable=unsubscriptable-object
+                snapshot.files[validated_data['path']],
                 context=self.get_serializer_context(),
             )
-            return Response(response_serializer.data, status=status.HTTP_201_CREATED)
-
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        else:
+            response_serializer = FileInfoSerializer(
+                [snapshot.files[validated_data['path']]
+                    for validated_data in serializer_data],
+                context=self.get_serializer_context(),
+                many=True
+            )
+        return Response(response_serializer.data, status=status.HTTP_201_CREATED)
 
     def destroy(self, _request, bundle_uuid, version_num=None, path=None):
         """ Delete files from a bundle. """

--- a/blockstore/apps/bundles/models.py
+++ b/blockstore/apps/bundles/models.py
@@ -102,6 +102,12 @@ class Bundle(models.Model):
     def __str__(self):
         return "Bundle {} - {}".format(self.uuid, self.slug)
 
+    def get_bundle_version(self, version_num=None):
+        """
+        Returns the given bundle version, or the most recent if no version_num specified.
+        """
+        return BundleVersion.get_bundle_version(self.uuid, version_num)
+
 
 class BundleVersion(models.Model):
     """
@@ -151,7 +157,22 @@ class BundleVersion(models.Model):
         return store.snapshot(self.bundle.uuid, self.snapshot_digest)
 
     def __str__(self):
-        return f"{self.bundle.uuid}@{self.version_num}"
+        return "{self.bundle.uuid}@{self.version_num}".format(self=self)
+
+    @classmethod
+    def get_bundle_version(cls, bundle_uuid=None, version_num=None):
+        """
+        Returns the requested bundle version, or the most recent if no version_num specified.
+
+        Will return None if there are no BundleVersions associated with the Bundle.
+        """
+        filter_kwargs = {
+            'bundle__uuid': bundle_uuid
+        }
+        if version_num:
+            filter_kwargs['version_num'] = version_num
+
+        return cls.objects.filter(**filter_kwargs).order_by('-version_num').first()
 
 
 class BundleLink(models.Model):

--- a/blockstore/apps/bundles/tests/test_models.py
+++ b/blockstore/apps/bundles/tests/test_models.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 
 from ..store import BundleDataStore
 from ..models import Bundle
-from .factories import CollectionFactory
+from .factories import CollectionFactory, BundleFactory
 
 
 class TestBundleVersionCreation(TestCase):
@@ -37,14 +37,20 @@ class TestBundleVersionCreation(TestCase):
         with self.assertRaises(Bundle.DoesNotExist):
             store.create_snapshot(bundle_uuid, file_mapping)
 
-        # Bundle creation and the first version
+        # Bundle creation
         bundle = Bundle.objects.create(
             uuid=bundle_uuid, title="Auto-Create Test Bundle", collection=self.collection
         )
+        self.assertIsNone(bundle.get_bundle_version())
+
+        # Create the first snapshot
         snapshot_1 = store.create_snapshot(bundle_uuid, file_mapping)
         self.assertEqual(bundle.versions.count(), 1)
         version_1 = bundle.versions.get(version_num=1)
         self.assertEqual(version_1.snapshot_digest, snapshot_1.hash_digest)
+
+        # Version 1 is the latest version
+        self.assertEqual(bundle.get_bundle_version(), version_1)
 
         # Second snapshot
         file_mapping = {
@@ -56,8 +62,47 @@ class TestBundleVersionCreation(TestCase):
         self.assertEqual(version_2.snapshot_digest, snapshot_2.hash_digest)
         self.assertNotEqual(snapshot_1, snapshot_2)
 
+        # Version 2 should now be the latest version, and we can still access the others.
+        self.assertEqual(bundle.get_bundle_version(), version_2)
+        self.assertEqual(bundle.get_bundle_version(1), version_1)
+        self.assertEqual(bundle.get_bundle_version(2), version_2)
+        self.assertIsNone(bundle.get_bundle_version(3))
+
         # Third version is going to point to the first snapshot (simulate a revert).
         version_3 = bundle.versions.create(
             version_num=3, snapshot_digest=snapshot_1.hash_digest
         )
         self.assertEqual(snapshot_1, version_3.snapshot())
+
+        # Version 3 is now the latest version
+        self.assertEqual(bundle.get_bundle_version(), version_3)
+
+
+class TestToString(TestCase):
+    """
+    Tests the string representations of the models.
+    """
+    def setUp(self):
+
+        super().setUp()
+
+        self.uuid1 = uuid.UUID('10000000000000000000000000000000')
+        self.uuid2 = uuid.UUID('20000000000000000000000000000000')
+        self.collection = CollectionFactory(uuid=self.uuid1, title="Collection 1")
+        self.bundle = BundleFactory(uuid=self.uuid2, collection=self.collection, slug="bundle-1")
+
+        store = BundleDataStore()
+        file_mapping = {
+            'hello.txt': ContentFile(b"Hello World!"),
+        }
+        self.snapshot = store.create_snapshot(self.uuid2, file_mapping)
+        self.version = self.bundle.versions.get(version_num=1)
+
+    def test_collection_str(self):
+        self.assertEqual(str(self.collection), " - ".join([str(self.uuid1), "Collection 1"]))
+
+    def test_bundle_str(self):
+        self.assertEqual(str(self.bundle), "Bundle {} - {}".format(self.uuid2, "bundle-1"))
+
+    def test_version_str(self):
+        self.assertEqual(str(self.version), "{}@{}".format(self.uuid2, 1))

--- a/blockstore/settings/base.py
+++ b/blockstore/settings/base.py
@@ -36,6 +36,7 @@ INSTALLED_APPS = (
 THIRD_PARTY_APPS = (
     'rest_framework',
     'rest_framework_swagger',
+    'django_filters',
     'social_django',
     'waffle',
 )

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,6 +4,7 @@ django-extensions
 django-rest-swagger
 django-waffle
 djangorestframework
+django-filter==2.0.0
 git+https://github.com/alanjds/drf-nested-routers.git
 edx-auth-backends
 pytz

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,6 +4,7 @@ django-extensions
 django-rest-swagger
 django-waffle
 djangorestframework
+djangorestframework-expander
 django-filter==2.0.0
 git+https://github.com/alanjds/drf-nested-routers.git
 edx-auth-backends

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 attrs<19.0.0
-django==1.11.15
+django>=1.11,<1.12
 django-extensions
 django-rest-swagger
 django-waffle

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 attrs<19.0.0
-django==1.11.14
+django==1.11.15
 django-extensions
 django-rest-swagger
 django-waffle

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,6 +2,7 @@
 -r base.txt
 
 coverage
+ddt
 diff-cover
 dj-inmemorystorage
 django_dynamic_fixture


### PR DESCRIPTION
Provides several improvements to the REST API, detailed below.

**JIRA tickets**:  LX-53, SE-281

**Testing instructions**:

- [x] Add expand field to /bundles/ and /bundle_versions/ to inline the files list:  b25d9a6 
   * Visit http://localhost:8888/api/v1/bundle/ and view a bundle version.
   * Visit http://localhost:8888/api/v1/bundle_versions/ and view a bundle version.
   * Append `?expand=files` to the urls above, and note that the `files` hyperlink is converted to an array of files data, which matches what was shown by following the `files` hyperlink.
   * Appending `?expand=files&format=json` also works.
   * Appending `?expand=files` to the `/api/v1/bundle/` and `/api/v1/bundle_versions/` list views has no effect (previous to f47b553, it threw an error).
- [x] Add filters to the endpoints: c47b482
   * list Bundles associated with a Collection, e.g. 
      http://localhost:8888/api/v1/bundles/?collection__uuid=4ffa83df9b93499e91c29f5a7ad9
   * list BundleVersions for a Bundle, e.g.
      http://localhost:8888/api/v1/bundle_versions/?bundle__uuid=33566cb9-e607-425b-8cd1-db0ad4ab97d7
   * list BundleVersions for a Collection, e.g.
      http://localhost:8888/api/v1/bundle_versions?bundle_collection__uuid=4ffa83df-9b93-499e-91c29f5a7ad9
- [x] Add PUT method to `BundleVersionViewSet` to allow changing `change_description`: 023d251
   * Visit http://localhost:8888/api/v1/bundle_versions/ and view a bundle version.
   * Update the `change_description` field and submit.
- [x] Allow posting multiple files at once: 3c93aee
   * This change cannot be tested from the DRF GUI
   * See the [`test_create_multiple_files`](https://github.com/open-craft/blockstore/commit/3c93aee20a9dead5c5036b816861f1da0f28c203#diff-3959f0e2e005ddd8ad570fb6febdea94R431) unit test for details on how this feature works.
- [x] Verify the exact output in view tests: 6fdae38 

**Reviewers**
- [ ] @symbolist 