### PR TITLE
WIP SE-342 LX-76 Make Blockstore work with MySQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: python
+sudo: false
 python:
     - 3.6
-sudo: false
-
+services:
+    - mysql
 cache: pip
 before_install:
     - "export DISPLAY=:99.0"

--- a/blockstore/settings/test.py
+++ b/blockstore/settings/test.py
@@ -3,18 +3,18 @@ import os
 from blockstore.settings.base import *
 
 
-# IN-MEMORY TEST DATABASE
+# MYSQL TEST DATABASE
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': ':memory:',
-        'USER': '',
-        'PASSWORD': '',
-        'HOST': '',
-        'PORT': '',
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'blockstore_test',
+        'USER': environ.get('BLOCKSTORE_MYSQL_USER', 'blockstore_user'),
+        'PASSWORD': environ.get('BLOCKSTORE_MYSQL_PASSWORD', 'blockstore_password'),
+        'HOST': environ.get('BLOCKSTORE_MYSQL_HOST', 'datastore'),
+        'PORT': int(environ.get('BLOCKSTORE_MYSQL_PORT', 3306)),
     },
 }
-# END IN-MEMORY TEST DATABASE
+# END MYSQL TEST DATABASE
 
 # So we don't leave mix Bundle files from test runs with our local dev server.
 DEFAULT_FILE_STORAGE = 'inmemorystorage.InMemoryStorage'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,22 @@ services:
       - "18250:18250"
     volumes:
       - ./:/blockstore/app/:cached
+    depends_on:
+      - "datastore"
+
+  datastore:
+    container_name: datastore
+    image: mysql:8.0
+    ports:
+        - "3306:3306"
+    volumes:
+      - ./datastore_volume:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_DATABASE=blockstore_test
+      - MYSQL_USER=blockstore_user
+      - MYSQL_PASSWORD=blockstore_password
+      - VIRTUAL_HOST=datastore_host
 
 networks:
   devstack:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,3 +7,4 @@ djangorestframework
 git+https://github.com/alanjds/drf-nested-routers.git
 edx-auth-backends
 pytz
+mysqlclient

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -3,3 +3,4 @@
 -r docs.txt
 
 django-debug-toolbar
+mysqlclient

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,3 +12,4 @@ pycodestyle
 pytest
 pytest-cov
 pytest-django
+mysqlclient


### PR DESCRIPTION
A setup to run tests in MySQL instead of SQLite

## Description

A setup to run tests in MySQL instead of SQLite. It defines new dependencies in `requirements.txt` files, creates a new container for the `docker-compose` file, and creates new settings (environment variables) to setup a (MySQL) database instance.

## Testing Checklist
- [ ] Include unit tests
- [ ] All unit tests passes
- [ ] Check that Database migrations are backwards-compatible
- [ ] Manually test right-to-left languages and i18n
  of the changes

## Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @UmanShahzad 

### Areas to Consider
- [ ] Database migrations
    - Are they backwards compatible?
    - When they run on production, how long will they take? Will they lock the table?
