### PR TITLE
Update Tagstore to work with MySQL, Blockstore to work with utf8mb4

### DIFF
--- a/blockstore/apps/mysql_unicode/__init__.py
+++ b/blockstore/apps/mysql_unicode/__init__.py
@@ -1,0 +1,5 @@
+"""
+An app to force use of the non-broken Unicode character encoding with MySQL.
+
+See migrations/0001_initial.py for details.
+"""

--- a/blockstore/apps/mysql_unicode/migrations/0001_initial.py
+++ b/blockstore/apps/mysql_unicode/migrations/0001_initial.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# By default django and many MySQL installations use a broken
+# version of unicode ("utf8"). We should always use "utf8mb4"
+# which is a correct/non-broken unicode character set, and fully
+# supports characters in the supplementary multilingual plane,
+# such as emoji, musical notation, mathematical alphanumerics,
+# hieroglyphs, cuneiform, rare/historic language symbols
+# (sometimes still used in asian family names), and more.
+#
+# Django has no supported way to change the character set and collation
+# so we change it here in a migration.
+# By specifying "run_before", we can force this to be the first migration.
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    run_before = [
+        ('contenttypes', '0001_initial'),
+        ('core', '0001_initial'),
+        ('tagstore_django', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            'ALTER DATABASE CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;',
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]

--- a/blockstore/settings/base.py
+++ b/blockstore/settings/base.py
@@ -42,6 +42,7 @@ THIRD_PARTY_APPS = (
 )
 
 PROJECT_APPS = (
+    'blockstore.apps.mysql_unicode',
     'blockstore.apps.core',
     'blockstore.apps.api',
     'blockstore.apps.bundles.apps.BundlesConfig',
@@ -74,12 +75,19 @@ WSGI_APPLICATION = 'blockstore.wsgi.application'
 # Set this value in the environment-specific files (e.g. local.py, production.py, test.py)
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.',
+        'ENGINE': 'django.db.backends.mysql',
         'NAME': '',
         'USER': '',
         'PASSWORD': '',
         'HOST': '',  # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
         'PORT': '',  # Set to empty string for default.
+        'OPTIONS': {
+            # Use a non-broken unicode encoding. See "mysql_unicode/migrations/0001_initial.py"
+            # for details. Together with that migration, this setting will force the use of
+            # the correct unicode implementation.
+            # Note that this limits the length of InnoDB indexed columns to 191 characters.
+            'charset': 'utf8mb4',
+        },
     }
 }
 
@@ -171,6 +179,12 @@ ENABLE_AUTO_AUTH = False
 AUTO_AUTH_USERNAME_PREFIX = 'auto_auth_'
 
 SOCIAL_AUTH_STRATEGY = 'auth_backends.strategies.EdxDjangoStrategy'
+# Django model max_length overrides required for MySQL utf8mb4 charset:
+SOCIAL_AUTH_UID_LENGTH = 190
+SOCIAL_AUTH_NONCE_SERVER_URL_LENGTH = 190
+SOCIAL_AUTH_ASSOCIATION_SERVER_URL_LENGTH = 190
+SOCIAL_AUTH_ASSOCIATION_HANDLE_LENGTH = 190
+SOCIAL_AUTH_EMAIL_LENGTH = 190
 
 # Set these to the correct values for your OAuth2/OpenID Connect provider (e.g., devstack)
 SOCIAL_AUTH_EDX_OIDC_KEY = 'replace-me'

--- a/blockstore/settings/local.py
+++ b/blockstore/settings/local.py
@@ -23,6 +23,13 @@ DATABASES = {
         'PASSWORD': os.environ.get('MYSQL_ROOT_PASSWORD', ''),
         'HOST': os.environ.get('MYSQL_HOST', 'mysql'),
         'PORT': int(os.environ.get('MYSQL_PORT', '3306')),
+        'OPTIONS': {
+            # Use a non-broken unicode encoding. See "mysql_unicode/migrations/0001_initial.py"
+            # for details. Together with that migration, this setting will force the use of
+            # the correct unicode implementation.
+            # Note that this limits the length of InnoDB indexed columns to 191 characters.
+            'charset': 'utf8mb4',
+        },
     }
 }
 # END DATABASE CONFIGURATION

--- a/blockstore/settings/production.py
+++ b/blockstore/settings/production.py
@@ -24,6 +24,7 @@ DB_OVERRIDES = dict(
     NAME=environ.get('DB_MIGRATION_NAME', DATABASES['default']['NAME']),
     HOST=environ.get('DB_MIGRATION_HOST', DATABASES['default']['HOST']),
     PORT=environ.get('DB_MIGRATION_PORT', DATABASES['default']['PORT']),
+    OPTIONS=environ.get('DB_MIGRATION_OPTIONS', DATABASES['default']['OPTIONS']),
 )
 
 for override, value in DB_OVERRIDES.iteritems():

--- a/blockstore/settings/test.py
+++ b/blockstore/settings/test.py
@@ -12,6 +12,13 @@ DATABASES = {
         'PASSWORD': os.environ.get('MYSQL_ROOT_PASSWORD', ''),
         'HOST': os.environ.get('MYSQL_HOST', 'mysql'),
         'PORT': int(os.environ.get('MYSQL_PORT', '3306')),
+        'OPTIONS': {
+            # Use a non-broken unicode encoding. See "mysql_unicode/migrations/0001_initial.py"
+            # for details. Together with that migration, this setting will force the use of
+            # the correct unicode implementation.
+            # Note that this limits the length of InnoDB indexed columns to 191 characters.
+            'charset': 'utf8mb4',
+        },
     },
 }
 # END MYSQL TEST DATABASE

--- a/tagstore/backends/django.py
+++ b/tagstore/backends/django.py
@@ -33,7 +33,7 @@ class DjangoTagstore(Tagstore):
             return None
         return tax.as_tuple
 
-    def _add_tag_to_taxonomy(self, taxonomy_uid: int, tag: str, parent_tag: Optional[str] = None) -> None:
+    def _add_tag_to_taxonomy(self, taxonomy_uid: int, tag: str, parent_tag: Optional[str] = None) -> str:
         if parent_tag:
             # Check the parent tag:
             try:
@@ -51,6 +51,7 @@ class DjangoTagstore(Tagstore):
         if not created:
             if db_tag.path != path:
                 raise ValueError("That tag already exists with a different parent tag.")
+        return db_tag.tag
 
     def list_tags_in_taxonomy(self, uid: int) -> Iterator[Tag]:
         for tag in TagModel.objects.filter(taxonomy_id=uid).order_by('tag'):

--- a/tagstore/backends/tagstore_django/migrations/0001_initial.py
+++ b/tagstore/backends/tagstore_django/migrations/0001_initial.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.BigAutoField(primary_key=True, serialize=False)),
                 ('entity_type', models.CharField(max_length=180)),
-                ('external_id', models.CharField(max_length=255)),
+                ('external_id', models.CharField(max_length=180)),
             ],
             options={
                 'db_table': 'tagstore_entity',
@@ -65,9 +65,5 @@ class Migration(migrations.Migration):
         migrations.AlterUniqueTogether(
             name='entity',
             unique_together=set([('entity_type', 'external_id')]),
-        ),
-        migrations.RunSQL(
-            sql=r'CREATE INDEX "tagstore_tag_uppercase" ON "tagstore_tag" (UPPER("tag"));',
-            reverse_sql=r'DROP INDEX "tagstore_tag_uppercase";'
         ),
     ]

--- a/tagstore/backends/tests.py
+++ b/tagstore/backends/tests.py
@@ -68,8 +68,9 @@ class AbstractBackendTest:
         self.assertEqual(len([t for t in self.tagstore.list_tags_in_taxonomy(tax.uid)]), 0)
         tag1 = self.tagstore.add_tag_to_taxonomy('testing', tax)
         tag2 = self.tagstore.add_tag_to_taxonomy('Testing', tax)
+        self.assertEqual(tag2.tag, 'testing')  # It should have returned the existing tag's case
         tags = set([t for t in self.tagstore.list_tags_in_taxonomy(tax.uid)])
-        self.assertEqual(len(tags), 2)
+        self.assertEqual(len(tags), 1)
         self.assertEqual(tags, {tag1, tag2})
 
     def test_allowed_tag_names(self):

--- a/tagstore/models/tag.py
+++ b/tagstore/models/tag.py
@@ -8,5 +8,8 @@ class Tag(NamedTuple):
     """
     A tag that can be applied to content.
     """
-    taxonomy_uid: int  # The Unique ID of the taxonomy which owns this tag
-    tag: str  # The text of this tag, which also serves as its identifier. Unique within this taxonomy.
+    # The Unique ID of the taxonomy which owns this tag
+    taxonomy_uid: int
+    # The text of this tag, which also serves as its identifier.
+    # Case is preserved but within a taxonomy, tags must be case-insensitively unique.
+    tag: str

--- a/tagstore/tagstore.py
+++ b/tagstore/tagstore.py
@@ -32,9 +32,10 @@ class Tagstore:
         self, tag: str, taxonomy: Union[TaxonomyId, TaxonomyMetadata], parent_tag: Optional[Tag] = None
     ) -> Tag:
         """
-        Add the specified tag to the given taxonomy
+        Add the specified tag to the given taxonomy, and retuns it.
 
-        Will be a no-op if the tag already exists in the taxonomy.
+        Will be a no-op if the tag already exists in the taxonomy (case-insensitive),
+        however the returned (existing) Tag may differ in case.
         Will raise a ValueError if the specified taxonomy or parent doesn't exist.
         Will raise a ValueError if trying to add a child tag that
         already exists anywhere in the taxonomy.
@@ -61,12 +62,15 @@ class Tagstore:
                 raise ValueError("A tag cannot have a parent from another taxonomy")
             parent_tag_str = parent_tag.tag
 
-        self._add_tag_to_taxonomy(taxonomy_uid=taxonomy_uid, tag=tag, parent_tag=parent_tag_str)
-        return Tag(taxonomy_uid=taxonomy_uid, tag=tag)
+        tag_value = self._add_tag_to_taxonomy(taxonomy_uid=taxonomy_uid, tag=tag, parent_tag=parent_tag_str)
+        return Tag(taxonomy_uid=taxonomy_uid, tag=tag_value)
 
-    def _add_tag_to_taxonomy(self, taxonomy_uid: int, tag: str, parent_tag: Optional[str] = None) -> None:
+    def _add_tag_to_taxonomy(self, taxonomy_uid: int, tag: str, parent_tag: Optional[str] = None) -> str:
         """
         Subclasses should override this method to implement adding tags to a taxonomy.
+
+        It should return the 'tag' value of the newly created tag, or the existing tag
+        if a tag already exists.
         """
         raise NotImplementedError()
 
@@ -81,9 +85,8 @@ class Tagstore:
         """
         Get a list of all tags in the given taxonomy, in hierarchical and alphabetical order.
 
-        Returns tuples of (Tag, parent_tag) where parent_tag is the 'tag' string which uniquely
-        identifies the parent tag. This method guarantees that parent tags will be returned
-        before their child tags.
+        Returns tuples of (Tag, parent_tag).
+        This method guarantees that parent tags will be returned before their child tags.
         """
         raise NotImplementedError()
         yield None  # Required to make this non-implementation also a generator. pylint: disable=unreachable


### PR DESCRIPTION
When I rebased https://github.com/open-craft/blockstore/pull/7 in preparation for merge, a couple tests broke (specifically, emoji tags weren't working and case-sensitive tags + case-insensitive search was not working). Here's what eventually I arrived at to fix them.

This PR:
* Uses a migration to force Blockstore's MySQL database to use the `utf8mb4` encoding and `utf8mb4_unicode_ci` collation. These are generally recommended by everyone for new projects, and we already had some design decisions in place to be compatible with those. (However, without the fixes in this PR, it wasn't actually possible to use blockstore with `utf8mb4`)
* Changes tagstore from being case-sensitive for tags to "preserve case but tags must be case-insensitively unique". I think that's better anyways, and it doesn't matter because on MySQL (and only MySQL) django doesn't allow you to do case-insensitive searches on a column that has case-sensitive collation.

Testing instructions:

1. Drop all tables in your blockstore database, or re-create it, or run all django app migrations to `zero`.
1. Check out this branch.
1. Run `make blockstore-shell` then `./manage.py migrate`
1. Run `make test` to confirm the tests pass.