### PR TITLE
Tagstore API improvements

### DIFF
--- a/tagstore/README.rst
+++ b/tagstore/README.rst
@@ -13,7 +13,7 @@ Features
 * Python 3 API with type hints
 * Allows any "entity" to be tagged, where an entity could be a user, a block, a collection, etc.
 * Allows rich searching for entities by tags. e.g. "Find all large animals" will return an entity that was tagged with "large" and "dog", since it knows that the "dog" tag is a type of "animal" tag.
-* Designed to support multiple tag storage backends, although the current version of Tagstore only includes a Django ORM backend, which stores tags in MySQL/PostgeSQL/SQLite. (A reasonably complete Neo4j backend implementation also existed in an early version and can found at https://github.com/open-craft/blockstore/pull/7/commits/05503ade0d29296119578837fe059a04e57209e0)
+* Designed to support multiple tag storage backends, although the current version of Tagstore only includes a Django ORM backend, which stores tags in MySQL/PostgeSQL/SQLite. (A reasonably complete Neo4j backend implementation also existed in an early version and can found at https://github.com/open-craft/blockstore/commit/714b22f8456fb3b509aca54f59dc96de060d36fe)
 
 Non-features
 ------------
@@ -40,6 +40,18 @@ Here is an example of using the Tagstore API::
     pine = biology.add_tag('pine', parent_tag=conifer)
     aster = biology.add_tag('aster', parent_tag=plant)
 
+    # Print tag hierarchy tree:
+    depths = {}
+    for (tag, parent) in biology.list_tags_hierarchically():
+        depths[tag] = depths[parent] + 1 if parent else 0
+        print(("  " * depths[tag]) + tag.name)
+    # The resulting hierarchy that gets printed out is:
+    #   plant
+    #     aster
+    #     conifer
+    #       cypress
+    #       pine
+
     # Create a "sizes" taxonomy:
     sizes = tagstore.create_taxonomy("sizes", owner_id=None)
     small = sizes.add_tag('small')
@@ -55,29 +67,29 @@ Here is an example of using the Tagstore API::
     tagstore.add_tag_to(cypress, redwood)
 
     # Find all asters
-    set([e for e in tagstore.get_entities_tagged_with(aster)])
+    set(tagstore.get_entities_tagged_with(aster))
     # result: {dandelion}
 
     # plants
-    set([e for e in tagstore.get_entities_tagged_with(plant)])
+    set(tagstore.get_entities_tagged_with(plant))
     # result: {dandelion, redwood}
 
     # small plants
-    set([e for e in tagstore.get_entities_tagged_with_all({plant, small})])
+    set(tagstore.get_entities_tagged_with_all({plant, small}))
     # result: {dandelion}
 
     # plants, with no tag inheritance
-    set([e for e in tagstore.get_entities_tagged_with(plant, include_child_tags=False)])
+    set(tagstore.get_entities_tagged_with(plant, include_child_tags=False))
     # result: set()
 
     # conifers
-    set([e for e in tagstore.get_entities_tagged_with(conifer)])
+    set(tagstore.get_entities_tagged_with(conifer))
     # result: {redwood}
 
-    # small things starting with "d"
-    set([e for e in tagstore.get_entities_tagged_with(
-        small, entity_types=['thing'], external_id_prefix='d'
-    )])
+    # plants starting with "d"
+    set(tagstore.get_entities_tagged_with(
+        plant, entity_types=['thing'], external_id_prefix='d'
+    ))
     # result: {dandelion}
 
 

--- a/tagstore/README.rst
+++ b/tagstore/README.rst
@@ -34,17 +34,17 @@ Here is an example of using the Tagstore API::
 
     # Create a biology taxonomy:
     biology = tagstore.create_taxonomy("Biology", owner_id=None)
-    plant = tagstore.add_tag_to_taxonomy('plant', biology)
-    conifer = tagstore.add_tag_to_taxonomy('conifer', biology, parent_tag=plant)
-    cypress = tagstore.add_tag_to_taxonomy('cypress', biology, parent_tag=conifer)
-    pine = tagstore.add_tag_to_taxonomy('pine', biology, parent_tag=conifer)
-    aster = tagstore.add_tag_to_taxonomy('aster', biology, parent_tag=plant)
+    plant = biology.add_tag('plant')
+    conifer = biology.add_tag('conifer', parent_tag=plant)
+    cypress = biology.add_tag('cypress', parent_tag=conifer)
+    pine = biology.add_tag('pine', parent_tag=conifer)
+    aster = biology.add_tag('aster', parent_tag=plant)
 
     # Create a "sizes" taxonomy:
     sizes = tagstore.create_taxonomy("sizes", owner_id=None)
-    small = tagstore.add_tag_to_taxonomy('small', sizes)
-    med = tagstore.add_tag_to_taxonomy('med', sizes)
-    large = tagstore.add_tag_to_taxonomy('large', sizes)
+    small = sizes.add_tag('small')
+    med = sizes.add_tag('med')
+    large = sizes.add_tag('large')
 
     # Tag some entities:
     dandelion = EntityId(entity_type='thing', external_id='dandelion')

--- a/tagstore/backends/django.py
+++ b/tagstore/backends/django.py
@@ -15,7 +15,7 @@ class DjangoTagstore(Tagstore):
     Django tag storage backend.
     """
 
-    def create_taxonomy(self, name: str, owner_id: Optional[UserId]) -> Taxonomy:
+    def create_taxonomy(self, name: str, owner_id: Optional[UserId] = None) -> Taxonomy:
         """ Create a new taxonomy with the specified name and owner. """
         owner_obj: Optional[UserId] = None
         if owner_id is not None:

--- a/tagstore/backends/django.py
+++ b/tagstore/backends/django.py
@@ -53,6 +53,18 @@ class DjangoTagstore(Tagstore):
                 raise ValueError("That tag already exists with a different parent tag.")
         return db_tag.tag
 
+    def get_tag_in_taxonomy(self, tag: str, taxonomy_uid: TaxonomyId) -> Optional[Tag]:
+        """
+        If a tag with the specified name (case insensitive) exists in this taxonomy, get it.
+
+        Otherwise returns None.
+        """
+        try:
+            tag_obj = TagModel.objects.get(taxonomy_id=taxonomy_uid, tag=tag)
+            return Tag(taxonomy_uid=taxonomy_uid, tag=tag_obj.tag)
+        except TagModel.DoesNotExist:
+            return None
+
     def list_tags_in_taxonomy(self, taxonomy_uid: TaxonomyId) -> Iterator[Tag]:
         for tag in TagModel.objects.filter(taxonomy_id=taxonomy_uid).order_by('tag'):
             yield Tag(taxonomy_uid=taxonomy_uid, tag=tag.tag)

--- a/tagstore/backends/tagstore_django/migrations/0001_initial.py
+++ b/tagstore/backends/tagstore_django/migrations/0001_initial.py
@@ -29,12 +29,12 @@ class Migration(migrations.Migration):
             name='Tag',
             fields=[
                 ('id', models.BigAutoField(primary_key=True, serialize=False)),
-                ('tag', models.CharField(max_length=180)),
+                ('name', models.CharField(db_column='tag', max_length=180)),
                 ('path', models.CharField(db_index=True, max_length=180)),
             ],
             options={
                 'db_table': 'tagstore_tag',
-                'ordering': ('tag',),
+                'ordering': ('name',),
             },
         ),
         migrations.CreateModel(
@@ -60,7 +60,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='tag',
-            unique_together=set([('taxonomy', 'tag')]),
+            unique_together=set([('taxonomy', 'name')]),
         ),
         migrations.AlterUniqueTogether(
             name='entity',

--- a/tagstore/backends/tagstore_django/models.py
+++ b/tagstore/backends/tagstore_django/models.py
@@ -5,7 +5,8 @@ from typing import Optional
 
 from django.db import models
 
-from tagstore.models import EntityId, TaxonomyMetadata, UserId, Tag as TagTuple
+from tagstore import Tagstore
+from tagstore.models import EntityId, Taxonomy as TaxonomyTuple, UserId, Tag as TagTuple
 
 # If MySQL is configured to use utf8mb4 (correct utf8), indexed
 # columns have a max length of 191. Until Django supports limiting index
@@ -48,10 +49,9 @@ class Taxonomy(models.Model):
     class Meta:
         db_table = 'tagstore_taxonomy'
 
-    @property
-    def as_tuple(self) -> TaxonomyMetadata:
+    def as_tuple(self, tagstore: Tagstore) -> TaxonomyTuple:
         owner_id = UserId(self.owner.as_tuple) if self.owner is not None else None
-        return TaxonomyMetadata(uid=self.id, name=self.name, owner_id=owner_id)
+        return TaxonomyTuple(uid=self.id, name=self.name, owner_id=owner_id, tagstore=tagstore)
 
 
 class Tag(models.Model):

--- a/tagstore/backends/tagstore_django/models.py
+++ b/tagstore/backends/tagstore_django/models.py
@@ -61,7 +61,7 @@ class Tag(models.Model):
     id = models.BigAutoField(primary_key=True)
     taxonomy = models.ForeignKey(Taxonomy, null=False)
     # The tag string, like "good problem".
-    tag = models.CharField(max_length=MAX_CHAR_FIELD_LENGTH)
+    name = models.CharField(max_length=MAX_CHAR_FIELD_LENGTH, db_column='tag')
     # Materialized path. Lowercase and always ends with ":".
     # A simple tag like "good-problem" would have a path of "good-problem:"
     # A tag like "mammal" that is a child of "animal" would have a path of
@@ -73,15 +73,15 @@ class Tag(models.Model):
 
     class Meta:
         db_table = 'tagstore_tag'
-        ordering = ('tag', )
+        ordering = ('name', )
         unique_together = (
-            ('taxonomy', 'tag'),
+            ('taxonomy', 'name'),
             # Note that (taxonomy, path) is also unique but we don't bother
             # with an index for that.
         )
 
     @classmethod
-    def make_path(cls, taxonomy_id: int, tag: str, parent_path: str = '') -> str:
+    def make_path(cls, taxonomy_id: int, name: str, parent_path: str = '') -> str:
         """
         Return the full 'materialized path' for use in the path field.
 
@@ -91,9 +91,9 @@ class Tag(models.Model):
         prefix = str(taxonomy_id) + cls.PATH_SEP
         if parent_path:
             assert parent_path.startswith(prefix)
-            return parent_path + tag.lower() + cls.PATH_SEP
+            return parent_path + name.lower() + cls.PATH_SEP
         else:
-            return prefix + tag.lower() + cls.PATH_SEP
+            return prefix + name.lower() + cls.PATH_SEP
 
     @property
     def parent_tag_tuple(self) -> Optional[TagTuple]:
@@ -106,4 +106,4 @@ class Tag(models.Model):
         parts = self.path.split(self.PATH_SEP)
         if len(parts) <= 3:
             return None
-        return TagTuple(taxonomy_uid=self.taxonomy_id, tag=parts[-3])
+        return TagTuple(taxonomy_uid=self.taxonomy_id, name=parts[-3])

--- a/tagstore/backends/tests.py
+++ b/tagstore/backends/tests.py
@@ -72,13 +72,13 @@ class AbstractBackendTest:
         self.assertEqual(len([t for t in tax.list_tags()]), 0)
         tag1 = tax.add_tag('testing')
         tag2 = tax.add_tag('Testing')
-        self.assertEqual(tag2.tag, 'testing')  # It should have returned the existing tag's case
+        self.assertEqual(tag2.name, 'testing')  # It should have returned the existing tag's case
         tags = set([t for t in tax.list_tags()])
         self.assertEqual(len(tags), 1)
         self.assertEqual(tags, {tag1, tag2})
         # get_tag should also respect the original case:
-        self.assertEqual(tax.get_tag('testing').tag, 'testing')
-        self.assertEqual(tax.get_tag('teSTING').tag, 'testing')
+        self.assertEqual(tax.get_tag('testing').name, 'testing')
+        self.assertEqual(tax.get_tag('teSTING').name, 'testing')
 
     def test_allowed_tag_names(self):
         """ add_tag_to_taxonomy will allow these tags """
@@ -94,7 +94,7 @@ class AbstractBackendTest:
         tax = self.tagstore.create_taxonomy("TestTax", owner_id=some_user)
         for tag in valid_tags:
             tax.add_tag(tag)
-        tags_created = set([t.tag for t in tax.list_tags()])
+        tags_created = set([t.name for t in tax.list_tags()])
         self.assertEqual(tags_created, set(valid_tags))
 
     def test_forbidden_tag_names(self):
@@ -181,7 +181,7 @@ class AbstractBackendTest:
         tags_in = ['Zulu', 'Uniform', 'Foxtrot', 'Βήτα', 'Alfa', 'Alpha', 'Αλφα']
         tags_out_expected = ['Alfa', 'Alpha', 'Foxtrot', 'Uniform', 'Zulu', 'Αλφα', 'Βήτα']
         tax = self._create_taxonomy_with_tags(tags_in)
-        tags_out = [t.tag for t in tax.list_tags()]
+        tags_out = [t.name for t in tax.list_tags()]
         self.assertEqual(tags_out, tags_out_expected)
 
     def test_list_tags_in_taxonomy_hierarchically(self):
@@ -208,13 +208,13 @@ class AbstractBackendTest:
         tags_in = ['Zulu', 'Uniform', 'Foxtrot', 'Βήτα', 'Alfa', 'Alpha', 'Αλφα']
         tax = self._create_taxonomy_with_tags(tags_in)
         # Contains 'al' (case insensitive)
-        results = [t.tag for t in tax.list_tags_containing("al")]
+        results = [t.name for t in tax.list_tags_containing("al")]
         self.assertEqual(results, ['Alfa', 'Alpha'])
         # Contains 'FO' (case insensitive)
-        results = [t.tag for t in tax.list_tags_containing("FO")]
+        results = [t.name for t in tax.list_tags_containing("FO")]
         self.assertEqual(results, ['Foxtrot', 'Uniform'])
         # Contains 'nomatch' (case insensitive)
-        results = [t.tag for t in tax.list_tags_containing("nomatch")]
+        results = [t.name for t in tax.list_tags_containing("nomatch")]
         self.assertEqual(results, [])
 
     # Tagging entities

--- a/tagstore/backends/tests.py
+++ b/tagstore/backends/tests.py
@@ -62,7 +62,12 @@ class AbstractBackendTest:
         self.assertEqual(set(t for t in tax.list_tags()), {tag, tag2})
 
     def test_case_sensitive_tags(self):
-        """ add_tag_to_taxonomy will add a tag to the given taxonomy """
+        """
+        Check case sensitive behavior
+
+        Tags preserve the case that they are originally created with.
+        Searching for tags is always case-insensitive.
+        """
         tax = self.tagstore.create_taxonomy("TestTax", owner_id=some_user)
         self.assertEqual(len([t for t in tax.list_tags()]), 0)
         tag1 = tax.add_tag('testing')
@@ -71,6 +76,9 @@ class AbstractBackendTest:
         tags = set([t for t in tax.list_tags()])
         self.assertEqual(len(tags), 1)
         self.assertEqual(tags, {tag1, tag2})
+        # get_tag should also respect the original case:
+        self.assertEqual(tax.get_tag('testing').tag, 'testing')
+        self.assertEqual(tax.get_tag('teSTING').tag, 'testing')
 
     def test_allowed_tag_names(self):
         """ add_tag_to_taxonomy will allow these tags """
@@ -154,6 +162,13 @@ class AbstractBackendTest:
         parent = tax2.add_tag('parent')
         with self.assertRaises(ValueError):
             tax.add_tag('child', parent_tag=parent)
+
+    def test_get_tag_in_taxonomy(self):
+        """ get_tag_in_taxonomy will retrieve Tags """
+        tax = self.tagstore.create_taxonomy("TestTax", owner_id=some_user)
+        self.assertEqual(tax.get_tag('testing'), None)
+        tag = tax.add_tag('testing')
+        self.assertEqual(tax.get_tag('testing'), tag)
 
     def _create_taxonomy_with_tags(self, tags: Iterable[str]) -> Taxonomy:
         tax = self.tagstore.create_taxonomy("TestTax", owner_id=some_user)

--- a/tagstore/models/__init__.py
+++ b/tagstore/models/__init__.py
@@ -3,5 +3,5 @@ Convenience module to allow easier importing of models
 """
 from .entity import EntityId
 from .tag import Tag
-from .taxonomy import TaxonomyId, TaxonomyMetadata
+from .taxonomy import TaxonomyId, Taxonomy
 from .user import UserId

--- a/tagstore/models/tag.py
+++ b/tagstore/models/tag.py
@@ -12,4 +12,4 @@ class Tag(NamedTuple):
     taxonomy_uid: int
     # The text of this tag, which also serves as its identifier.
     # Case is preserved but within a taxonomy, tags must be case-insensitively unique.
-    tag: str
+    name: str

--- a/tagstore/models/taxonomy.py
+++ b/tagstore/models/taxonomy.py
@@ -28,8 +28,9 @@ class Taxonomy(NamedTuple):
         """
         Add the specified tag to this given taxonomy, and return it.
 
-        Will be a no-op if the tag already exists in the taxonomy (case-insensitive),
-        however the returned (existing) Tag may differ in case.
+        If a Tag already exists in the taxonomy with the given name (case-insensitive)
+        and the given parent, then that Tag is returned and no changes are made.
+
         Will raise a ValueError if the specified taxonomy or parent doesn't exist.
         Will raise a ValueError if trying to add a child tag that
         already exists anywhere in the taxonomy.

--- a/tagstore/models/taxonomy.py
+++ b/tagstore/models/taxonomy.py
@@ -36,6 +36,14 @@ class Taxonomy(NamedTuple):
         """
         return self.tagstore.add_tag_to_taxonomy(tag, self.uid, parent_tag)
 
+    def get_tag(self, tag: str) -> Optional[Tag]:
+        """
+        If a tag with the specified name (case insensitive) exists in this taxonomy, get it.
+
+        Otherwise returns None.
+        """
+        return self.tagstore.get_tag_in_taxonomy(tag, self.uid)
+
     def list_tags(self) -> Iterator[Tag]:
         """
         Get a (flattened) list of all tags in the given taxonomy, in alphabetical order.

--- a/tagstore/models/taxonomy.py
+++ b/tagstore/models/taxonomy.py
@@ -24,7 +24,7 @@ class Taxonomy(NamedTuple):
 
     # Convenience methods:
 
-    def add_tag(self, tag: str, parent_tag: Optional[Tag] = None) -> Tag:
+    def add_tag(self, name: str, parent_tag: Optional[Tag] = None) -> Tag:
         """
         Add the specified tag to this given taxonomy, and retuns it.
 
@@ -34,7 +34,7 @@ class Taxonomy(NamedTuple):
         Will raise a ValueError if trying to add a child tag that
         already exists anywhere in the taxonomy.
         """
-        return self.tagstore.add_tag_to_taxonomy(tag, self.uid, parent_tag)
+        return self.tagstore.add_tag_to_taxonomy(name, self.uid, parent_tag)
 
     def get_tag(self, tag: str) -> Optional[Tag]:
         """

--- a/tagstore/models/taxonomy.py
+++ b/tagstore/models/taxonomy.py
@@ -1,16 +1,60 @@
 """
 A taxonomy is a collection of tags that can be applied to content.
 """
-from typing import NamedTuple, Optional, NewType
+from typing import Any, Iterator, NamedTuple, NewType, Optional, Tuple
+
+from .tag import Tag
 from .user import UserId
 
 TaxonomyId = NewType('TaxonomyId', int)
 
 
-class TaxonomyMetadata(NamedTuple):
+class Taxonomy(NamedTuple):
     """
     A taxonomy is a collection of tags that can be applied to content.
+
+    Is a NamedTuple for performance, simplicity, and immutability, but
+    we can change it to a full class at some point if needed.
     """
     uid: TaxonomyId
     name: str
     owner_id: Optional[UserId]
+
+    tagstore: Any  # Type is Tagstore but we can't define that without circular import
+
+    # Convenience methods:
+
+    def add_tag(self, tag: str, parent_tag: Optional[Tag] = None) -> Tag:
+        """
+        Add the specified tag to this given taxonomy, and retuns it.
+
+        Will be a no-op if the tag already exists in the taxonomy (case-insensitive),
+        however the returned (existing) Tag may differ in case.
+        Will raise a ValueError if the specified taxonomy or parent doesn't exist.
+        Will raise a ValueError if trying to add a child tag that
+        already exists anywhere in the taxonomy.
+        """
+        return self.tagstore.add_tag_to_taxonomy(tag, self.uid, parent_tag)
+
+    def list_tags(self) -> Iterator[Tag]:
+        """
+        Get a (flattened) list of all tags in the given taxonomy, in alphabetical order.
+        """
+        return self.tagstore.list_tags_in_taxonomy(self.uid)
+
+    def list_tags_hierarchically(self) -> Iterator[Tuple[Tag, Tag]]:
+        """
+        Get a list of all tags in the given taxonomy, in hierarchical and alphabetical order.
+
+        Returns tuples of (Tag, parent_tag).
+        This method guarantees that parent tags will be returned before their child tags.
+        """
+        return self.tagstore.list_tags_in_taxonomy_hierarchically(self.uid)
+
+    def list_tags_containing(self, text: str) -> Iterator[Tag]:
+        """
+        Get a (flattened) list of all tags in the given taxonomy that contain the given string
+        (case insensitive). This is intended to be used for auto-complete when users tag content
+        by typing tags into a text field, for example.
+        """
+        return self.tagstore.list_tags_in_taxonomy_containing(self.uid, text)

--- a/tagstore/models/taxonomy.py
+++ b/tagstore/models/taxonomy.py
@@ -26,7 +26,7 @@ class Taxonomy(NamedTuple):
 
     def add_tag(self, name: str, parent_tag: Optional[Tag] = None) -> Tag:
         """
-        Add the specified tag to this given taxonomy, and retuns it.
+        Add the specified tag to this given taxonomy, and return it.
 
         Will be a no-op if the tag already exists in the taxonomy (case-insensitive),
         however the returned (existing) Tag may differ in case.

--- a/tagstore/tagstore.py
+++ b/tagstore/tagstore.py
@@ -17,7 +17,7 @@ class Tagstore:
 
     # Taxonomy CRUD ##########################
 
-    def create_taxonomy(self, name: str, owner_id: Optional[UserId]) -> Taxonomy:
+    def create_taxonomy(self, name: str, owner_id: Optional[UserId] = None) -> Taxonomy:
         """ Create a new taxonomy with the specified name and owner. """
         raise NotImplementedError()
 
@@ -29,11 +29,12 @@ class Tagstore:
         """
         Add the specified tag to the given taxonomy, and retuns it.
 
-        Will be a no-op if the tag already exists in the taxonomy (case-insensitive),
-        however the returned (existing) Tag may differ in case.
+        If a Tag already exists in the taxonomy with the given name (case-insensitive)
+        and the given parent, then that Tag is returned and no changes are made.
+
         Will raise a ValueError if the specified taxonomy or parent doesn't exist.
         Will raise a ValueError if trying to add a child tag that
-        already exists anywhere in the taxonomy.
+        already exists but with a different parent tag.
 
         Subclasses should implement this by overriding _add_tag_to_taxonomy()
         """
@@ -59,7 +60,7 @@ class Tagstore:
         """
         Subclasses should override this method to implement adding tags to a taxonomy.
 
-        It should return the 'tag' value of the newly created tag, or the existing tag
+        It should return the 'name' value of the newly created tag, or the existing tag
         if a tag already exists.
         """
         raise NotImplementedError()

--- a/tagstore/tagstore.py
+++ b/tagstore/tagstore.py
@@ -25,7 +25,7 @@ class Tagstore:
         """ Get metadata about the given taxonomy """
         raise NotImplementedError()
 
-    def add_tag_to_taxonomy(self, tag: str, taxonomy_uid: TaxonomyId, parent_tag: Optional[Tag] = None) -> Tag:
+    def add_tag_to_taxonomy(self, name: str, taxonomy_uid: TaxonomyId, parent_tag: Optional[Tag] = None) -> Tag:
         """
         Add the specified tag to the given taxonomy, and retuns it.
 
@@ -37,25 +37,25 @@ class Tagstore:
 
         Subclasses should implement this by overriding _add_tag_to_taxonomy()
         """
-        if not isinstance(tag, str) or len(tag) < 1:
-            raise ValueError("Tag value must be a (non-empty) string.")
+        if not isinstance(name, str) or len(name) < 1:
+            raise ValueError("Tag name must be a (non-empty) string.")
 
-        if tag != tag.strip():
-            raise ValueError("Tag cannot start or end with whitespace.")
+        if name != name.strip():
+            raise ValueError("Tag name cannot start or end with whitespace.")
 
-        if any(char in tag for char in ':,;\n\r\\'):
-            raise ValueError("Tag contains an invalid character.")
+        if any(char in name for char in ':,;\n\r\\'):
+            raise ValueError("Tag name contains an invalid character.")
 
         parent_tag_str: Optional[str] = None
         if parent_tag is not None:
             if parent_tag.taxonomy_uid != taxonomy_uid:
                 raise ValueError("A tag cannot have a parent from another taxonomy")
-            parent_tag_str = parent_tag.tag
+            parent_tag_str = parent_tag.name
 
-        tag_value = self._add_tag_to_taxonomy(taxonomy_uid=taxonomy_uid, tag=tag, parent_tag=parent_tag_str)
-        return Tag(taxonomy_uid=taxonomy_uid, tag=tag_value)
+        final_name = self._add_tag_to_taxonomy(taxonomy_uid=taxonomy_uid, name=name, parent_tag=parent_tag_str)
+        return Tag(taxonomy_uid=taxonomy_uid, name=final_name)
 
-    def _add_tag_to_taxonomy(self, taxonomy_uid: TaxonomyId, tag: str, parent_tag: Optional[str] = None) -> str:
+    def _add_tag_to_taxonomy(self, taxonomy_uid: TaxonomyId, name: str, parent_tag: Optional[str] = None) -> str:
         """
         Subclasses should override this method to implement adding tags to a taxonomy.
 
@@ -64,7 +64,7 @@ class Tagstore:
         """
         raise NotImplementedError()
 
-    def get_tag_in_taxonomy(self, tag: str, taxonomy_uid: TaxonomyId) -> Optional[Tag]:
+    def get_tag_in_taxonomy(self, name: str, taxonomy_uid: TaxonomyId) -> Optional[Tag]:
         """
         If a tag with the specified name (case insensitive) exists in this taxonomy, get it.
 

--- a/tagstore/tagstore.py
+++ b/tagstore/tagstore.py
@@ -64,6 +64,14 @@ class Tagstore:
         """
         raise NotImplementedError()
 
+    def get_tag_in_taxonomy(self, tag: str, taxonomy_uid: TaxonomyId) -> Optional[Tag]:
+        """
+        If a tag with the specified name (case insensitive) exists in this taxonomy, get it.
+
+        Otherwise returns None.
+        """
+        raise NotImplementedError()
+
     def list_tags_in_taxonomy(self, taxonomy_uid: TaxonomyId) -> Iterator[Tag]:
         """
         Get a (flattened) list of all tags in the given taxonomy, in alphabetical order.


### PR DESCRIPTION
A few last API improvements to make this tagstore API a bit nicer, before we get too locked in.

* Per @symbolist's suggestion, `Tag.tag` is now `Tag.name` which I think is much nicer
* The API was missing a way to get an existing `Tag` without constructing it yourself, so I added a `get_tag()` method
* Made the `Taxonomy` class a bit more pythonic by giving it some methods, so now you can do `taxonomy.add_tag('foo')` instead of `tagstore.add_tag_to_taxonomy('foo', taxonomy)`

Testing instructions:
* The unit tests should cover everything quite well, so mostly review the code. You can also run the updated example code from `README.rst`.