### PR TITLE
Fix missing taxonomy_uid in templatetag

### DIFF
--- a/blockstore/templates/admin/tagstore_django/tag_hierarchy.html
+++ b/blockstore/templates/admin/tagstore_django/tag_hierarchy.html
@@ -6,7 +6,7 @@
     <ul>
     {% include "admin/tagstore_django/list_item.html" with taglist=tags.children taxonomy_uid=taxonomy_uid %}
     </ul>
+  {% endif %}
     <a href="/admin/tagstore_django/tag/add/?taxonomy={{ taxonomy_uid }}"
         class="addlink">{% trans "Add New Tag" %}</a>
-  {% endif %}
 </ul>

--- a/tagstore/backends/django.py
+++ b/tagstore/backends/django.py
@@ -49,7 +49,7 @@ class DjangoTagstore(Tagstore):
             defaults={'path': path},
         )
         if not created:
-            if db_tag.path != path:
+            if db_tag.path.lower() != path.lower():
                 raise ValueError("That tag already exists with a different parent tag.")
         return db_tag.name
 
@@ -94,7 +94,7 @@ class DjangoTagstore(Tagstore):
         taxonomy_uid_as_int = int(taxonomy_uid)
         for tag in TagModel.objects.filter(taxonomy_id=taxonomy_uid_as_int).order_by('path'):
             node = {'name': tag.name, 'id': tag.id, 'children': []}
-            as_tuple = Tag(taxonomy_uid=taxonomy_uid_as_int, name=tag.name.lower())
+            as_tuple = Tag(taxonomy_uid=taxonomy_uid_as_int, name=tag.name)
             all_nodes[as_tuple] = node
             all_nodes[tag.parent_tag_tuple]['children'].append(node)
         return root

--- a/tagstore/backends/django.py
+++ b/tagstore/backends/django.py
@@ -94,7 +94,7 @@ class DjangoTagstore(Tagstore):
         taxonomy_uid_as_int = int(taxonomy_uid)
         for tag in TagModel.objects.filter(taxonomy_id=taxonomy_uid_as_int).order_by('path'):
             node = {'name': tag.name, 'id': tag.id, 'children': []}
-            as_tuple = Tag(taxonomy_uid=taxonomy_uid_as_int, name=tag.name)
+            as_tuple = Tag(taxonomy_uid=taxonomy_uid_as_int, name=tag.name.lower())
             all_nodes[as_tuple] = node
             all_nodes[tag.parent_tag_tuple]['children'].append(node)
         return root

--- a/tagstore/backends/tagstore_django/models.py
+++ b/tagstore/backends/tagstore_django/models.py
@@ -70,7 +70,7 @@ class Tag(models.Model):
     taxonomy = models.ForeignKey(Taxonomy, null=False)
     # The tag string, like "good problem".
     name = models.CharField(max_length=MAX_CHAR_FIELD_LENGTH, db_column='tag')
-    # Materialized path. Lowercase and always ends with ":".
+    # Materialized path. Always ends with ":".
     # A simple tag like "good-problem" would have a path of "good-problem:"
     # A tag like "mammal" that is a child of "animal" would have a path of
     # "animal:mammal:". Tags are not allowed to contain the ":" character
@@ -99,9 +99,9 @@ class Tag(models.Model):
         prefix = str(taxonomy_id) + cls.PATH_SEP
         if parent_path:
             assert parent_path.startswith(prefix)
-            return parent_path + name.lower() + cls.PATH_SEP
+            return parent_path + name + cls.PATH_SEP
         else:
-            return prefix + name.lower() + cls.PATH_SEP
+            return prefix + name + cls.PATH_SEP
 
     @property
     def parent_tag_tuple(self) -> Optional[TagTuple]:

--- a/tagstore/backends/tagstore_django/templatetags/tagstore_admin.py
+++ b/tagstore/backends/tagstore_django/templatetags/tagstore_admin.py
@@ -10,5 +10,8 @@ register = template.Library()
 def tag_hierarchy(taxonomy_uid):
     """ Renders a hierarchical view in HTML of Tag objects. """
     tagstore = DjangoTagstore()
-    tags = tagstore.get_tags_in_taxonomy_hierarchically_as_dict(taxonomy_uid)
-    return {'tags': tags, 'taxonomy_uid': taxonomy_uid}
+    if taxonomy_uid:
+        tags = tagstore.get_tags_in_taxonomy_hierarchically_as_dict(taxonomy_uid)
+        return {'tags': tags, 'taxonomy_uid': taxonomy_uid}
+    else:
+        return


### PR DESCRIPTION
## Description

@bradenmacdonald I am sorry for opening another PR on this branch, but I discovered a bug. The Django admin uses the same template for both change and add. There's no `taxonomy_uid` on the add page because it hasn't been created yet, so the call to `get_tags_in_taxonomy_hierarchically_as_dict` raises an exception when it tries to cast `taxonomy_uid` to an int.

ETA: Also fixed an issue with KeyErrors caused by uppercase letters in parent tags.

## Test Instructions

1. Go to http://0.0.0.0:18250/admin/tagstore_django/taxonomy/add/ , with and without this commit

## TODOs
If anything isn't yet done, list it here
- [x] Squash before merging
