### PR TITLE
Fix the logging error in devstack

### DIFF
--- a/blockstore/settings/local.py
+++ b/blockstore/settings/local.py
@@ -13,6 +13,11 @@ CACHES = {
 }
 # END CACHE CONFIGURATION
 
+# Docker does not support the syslog socket at /dev/log. Rely on the console.
+LOGGING['handlers']['local'] = {
+    'class': 'logging.NullHandler',
+}
+
 # DATABASE CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#databases
 DATABASES = {

--- a/blockstore/settings/test.py
+++ b/blockstore/settings/test.py
@@ -2,6 +2,10 @@ import os
 
 from blockstore.settings.base import *
 
+# Docker does not support the syslog socket at /dev/log. Rely on the console.
+LOGGING['handlers']['local'] = {
+    'class': 'logging.NullHandler',
+}
 
 # MYSQL TEST DATABASE
 DATABASES = {


### PR DESCRIPTION
## Description

This PR fixes the logging issue seen in devstack after #18 was merged, during web-requests and running tests.

## Test Instructions

To test it:
1. Start the server inside the shell, and make any request. There should not be any logging errors seen on the console.
2. From inside the shell, run the test scripts with `make validate`. There should not be any logging errors seen.
