### PR TITLE
Elastic Stack configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,9 @@ migrate: ## Apply database migrations
 runserver:  ## Run django development server
 	${VENV_BIN}/python manage.py runserver 0.0.0.0:18250
 
+static:  ## Collect static files
+	${VENV_BIN}/python manage.py collectstatic --noinput
+
 test: clean ## Run tests and generate coverage report
 	${VENV_BIN}/coverage run ./manage.py test blockstore tagstore --settings=blockstore.settings.test
 	${VENV_BIN}/coverage html

--- a/blockstore/settings/production.py
+++ b/blockstore/settings/production.py
@@ -1,4 +1,4 @@
-from os import environ
+import os
 import yaml
 
 from blockstore.settings.base import *
@@ -18,13 +18,13 @@ with open(CONFIG_FILE) as f:
     vars().update(config_from_yaml)
 
 DB_OVERRIDES = dict(
-    PASSWORD=environ.get('DB_MIGRATION_PASS', DATABASES['default']['PASSWORD']),
-    ENGINE=environ.get('DB_MIGRATION_ENGINE', DATABASES['default']['ENGINE']),
-    USER=environ.get('DB_MIGRATION_USER', DATABASES['default']['USER']),
-    NAME=environ.get('DB_MIGRATION_NAME', DATABASES['default']['NAME']),
-    HOST=environ.get('DB_MIGRATION_HOST', DATABASES['default']['HOST']),
-    PORT=environ.get('DB_MIGRATION_PORT', DATABASES['default']['PORT']),
-    OPTIONS=environ.get('DB_MIGRATION_OPTIONS', DATABASES['default']['OPTIONS']),
+    PASSWORD=os.environ.get('DB_MIGRATION_PASS', DATABASES['default']['PASSWORD']),
+    ENGINE=os.environ.get('DB_MIGRATION_ENGINE', DATABASES['default']['ENGINE']),
+    USER=os.environ.get('DB_MIGRATION_USER', DATABASES['default']['USER']),
+    NAME=os.environ.get('DB_MIGRATION_NAME', DATABASES['default']['NAME']),
+    HOST=os.environ.get('DB_MIGRATION_HOST', DATABASES['default']['HOST']),
+    PORT=os.environ.get('DB_MIGRATION_PORT', DATABASES['default']['PORT']),
+    OPTIONS=os.environ.get('DB_MIGRATION_OPTIONS', DATABASES['default']['OPTIONS']),
 )
 
 for override, value in DB_OVERRIDES.items():

--- a/blockstore/settings/production.py
+++ b/blockstore/settings/production.py
@@ -12,6 +12,12 @@ ALLOWED_HOSTS = ['*']
 
 LOGGING['handlers']['local']['level'] = 'INFO'
 
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.BasicAuthentication',
+    ),
+}
+
 CONFIG_FILE = get_env_setting('BLOCKSTORE_CFG')
 with open(CONFIG_FILE) as f:
     config_from_yaml = yaml.load(f)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - "18250:18250"
     volumes:
       - ./:/blockstore/app/:cached
+      - blockstore_venv:/blockstore/venv/
     environment:
       - ELASTICSEARCH_URL=edx.devstack.blockstore-elasticsearch:9200
       - MYSQL_DATABASE=blockstore_db
@@ -41,4 +42,5 @@ networks:
       name: devstack_default
 
 volumes:
+  blockstore_venv:
   elasticsearch_data:

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,5 +4,6 @@
 gevent
 gunicorn
 mysqlclient
+newrelic
 PyYAML
 python-memcached


### PR DESCRIPTION
## Description

- Adds a Make command to collect static assets.
- Fixes an import bug in `settings/production.py`.
- Adds 'rest_framework.authentication.BasicAuthentication' to production. We will later need to change this to OAuth.
- Adds missing newrelic dependency.
- Adds a docker volume for the venv so that provisioning is not needed on every up.

## Test Instructions

These changes are being used to provision servers for LX stage and preview. Check that provisioning of Blockstore service completes successfully.