### PR TITLE
Fix version of mysqlclient until Django 2.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,6 +12,8 @@ git+https://github.com/alanjds/drf-nested-routers.git
 edx-auth-backends
 elasticsearch>=6.0.0,<7.0.0
 elasticsearch-dsl>=6.0.0,<7.0.0
-mysqlclient
+# Can upgrade once we move to Django 2.0
+# https://github.com/PyMySQL/mysqlclient-python/issues/306
+mysqlclient>1.3,<1.4
 pytz
 sqlparse

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -3,6 +3,5 @@
 
 gevent
 gunicorn
-mysqlclient
 PyYAML
 python-memcached


### PR DESCRIPTION
## Description

Prevents `mysqlclient` from updating to `>=1.4`, to maintain compatibility with Django 1.11.

As noted in the comments, we can remove this restriction after upgrading to Django 2.

cf https://github.com/PyMySQL/mysqlclient-python/issues/306

## Test Instructions

Run `make dev.provision`

## TODOs

- [ ] Squash before merging

## Reviewer

- [ ] OpenCraft TBD