### PR TITLE
Remove duplicate mysql requirement

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -3,7 +3,6 @@
 
 gevent
 gunicorn
-mysqlclient
 newrelic
 PyYAML
 python-memcached


### PR DESCRIPTION
## Description

This fix removes the duplicate mysql requirements in the production.txt file. The requirement for mysql is already part of base.txt and the duplication in production.txt results in the failure of `make production-requirements` command.
