### PR TITLE
Properly fetch user_id during LMS SSO flow

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,17 +64,19 @@ Prerequisite: Have your Open edX `Devstack <https://github.com/edx/devstack>`_ p
 
 #. To log in to Blockstore, you'll need to configure SSO with your devstack.
 
-    #. Go to http://localhost:18000/admin/oauth2_provider/application/ and add a new application
-    #. Set "Client id" to ``blockstore-sso-key``
-    #. Set "Redirect uris" to ``http://localhost:18250/complete/edx-oauth2/``
-    #. Set "Client type" to "Confidential"
-    #. Set "Authorization grant type" to "Authorization code"
-    #. Set "Name" to `blockstore-sso`
-    #. Check "Skip authorization"
-    #. Press "Save and continue editing"
-    #. Copy ``blockstore/settings/private.py.example`` to ``blockstore/settings/private.py``
-    #. In ``private.py``, set ``SOCIAL_AUTH_EDX_OAUTH2_SECRET`` to the random "Client secret" value.
-    #. Now you can login at http://localhost:18250/login/
+   #. Go to http://localhost:18000/admin/oauth2_provider/application/ and add a new application
+   #. Set "Client id" to ``blockstore-sso-key``
+   #. Set "Redirect uris" to ``http://localhost:18250/complete/edx-oauth2/``
+   #. Set "Client type" to "Confidential"
+   #. Set "Authorization grant type" to "Authorization code"
+   #. Set "Name" to ``blockstore-sso``
+   #. Check "Skip authorization"
+   #. Press "Save and continue editing"
+   #. Go to http://localhost:18000/admin/oauth_dispatch/applicationaccess/
+   #. Click "Add Application Access +", choose Application: ``blockstore-sso`` and set Scopes to ``user_id``, then hit "Save"
+   #. Copy ``blockstore/settings/private.py.example`` to ``blockstore/settings/private.py``
+   #. In ``private.py``, set ``SOCIAL_AUTH_EDX_OAUTH2_SECRET`` to the random "Client secret" value.
+   #. Now you can login at http://localhost:18250/login/
 
 Get Help
 --------

--- a/blockstore/settings/base.py
+++ b/blockstore/settings/base.py
@@ -200,10 +200,6 @@ SOCIAL_AUTH_EDX_OAUTH2_KEY = 'replace-me'
 SOCIAL_AUTH_EDX_OAUTH2_SECRET = 'replace-me'
 SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = 'http://edx.devstack.lms:18000'
 SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT = 'http://localhost:18000'
-# For some reason the 'user_id' scope which is included by default is giving an invalid_scope error
-# so these two settings temporarily remove it:
-SOCIAL_AUTH_EDX_OAUTH2_SCOPE = ['profile', 'email']
-SOCIAL_AUTH_EDX_OAUTH2_IGNORE_DEFAULT_SCOPE = True
 
 # CORS Config
 CORS_ORIGIN_ALLOW_ALL = env('DJANGO_CORS_ORIGIN_ALLOW_ALL', default=False)


### PR DESCRIPTION
## Description

This is a quick follow-up to #38, to remove a workaround now that I know what settings on the LMS must be changed for the SSO flow to work as intended.

## Author Comments, Concerns, and Open Questions

## Test Instructions

Check out this branch and restart Blockstore. Configure your devstack per the updated README instructions in this PR, then login to Blockstore by going to http://localhost:18250/login in an incognito window.

Then go to http://localhost:18250/admin/social_django/usersocialauth/ and click on the user you used (e.g. "staff") and confirm that the user_id is present in the "Extra Data" JSON field.