### PR TITLE
Add authorization to Blockstore API [SE-1255]

### DIFF
--- a/blockstore/apps/api/permissions.py
+++ b/blockstore/apps/api/permissions.py
@@ -15,7 +15,7 @@ class IsSuperUserOrAuthorizedApplication(permissions.BasePermission):
       service user account. Tokens can be created at /admin/authtoken/token/
 
     Blockstore does not handle detailed (object-level/bundle-level)
-    authorization because it can rely on many details (enrollment, due dates,
+    authorization because it relies on many details (enrollment, due dates,
     cohorts, etc.) that Blockstore is not aware of. Instead, applications like
     the Open edX LMS have full access to Blockstore and are responsible for
     providing a limited subset of Blockstore functionality to authorized users
@@ -36,5 +36,5 @@ class IsSuperUserOrAuthorizedApplication(permissions.BasePermission):
             # This is a service user account for an app like the LMS.
             # It's allowed to do anything using the REST API.
             return True
-        # Nobody else is allowed to user the API:
+        # Nobody else is allowed to use the API:
         return False

--- a/blockstore/apps/api/permissions.py
+++ b/blockstore/apps/api/permissions.py
@@ -1,0 +1,40 @@
+"""
+Django Rest Framework Permissions/Authorization classes for Blockstore's API
+"""
+from rest_framework import permissions
+
+
+class IsSuperUserOrAuthorizedApplication(permissions.BasePermission):
+    """
+    DRF Permissions class that prevents any usage of the API unless
+    * The user is authenticated as a django superuser (is_superuser=True)
+    or
+    * The user is authenticated as a service user account with a valid
+      rest_framework.authtoken.models.Token associated. This is meant to be used
+      by other applications like the Open edX LMS which use this API via a
+      service user account. Tokens can be created at /admin/authtoken/token/
+
+    Blockstore does not handle detailed (object-level/bundle-level)
+    authorization because it can rely on many details (enrollment, due dates,
+    cohorts, etc.) that Blockstore is not aware of. Instead, applications like
+    the Open edX LMS have full access to Blockstore and are responsible for
+    providing a limited subset of Blockstore functionality to authorized users
+    via their own API or by partially proxying the Blockstore API.
+    """
+    message = 'Only administrators or authorized app service user accounts may use this API.'
+
+    def has_permission(self, request, view):
+        """
+        Check if the given request may proceed.
+        """
+        if not request.user or not request.user.is_authenticated:
+            return False
+        if request.user.is_superuser:
+            # Superusers are always allowed to do anything
+            return True
+        if request.auth and request.user.auth_token:
+            # This is a service user account for an app like the LMS.
+            # It's allowed to do anything using the REST API.
+            return True
+        # Nobody else is allowed to user the API:
+        return False

--- a/blockstore/apps/api/tests/__init__.py
+++ b/blockstore/apps/api/tests/__init__.py
@@ -1,1 +1,0 @@
-# Create your tests in sub-packages prefixed with "test_" (e.g. test_models).

--- a/blockstore/apps/api/v1/tests/test_authorization.py
+++ b/blockstore/apps/api/v1/tests/test_authorization.py
@@ -1,0 +1,77 @@
+"""
+Tests to check that the API is only accessible by superusers or authorized
+application service users. See
+    blockstore.apps.api.permissions.IsSuperUserOrAuthorizedApplication
+for details.
+"""
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
+
+User = get_user_model()
+
+
+class ApiAuthorizationTestCase(TestCase):
+    """
+    Check that the API authentication/authorization is working.
+    """
+
+    basic_read_urls = (
+        # API endpoints that support a GET requests and require no parameters
+        '/api/v1/collections',
+        '/api/v1/bundles',
+        '/api/v1/drafts',
+    )
+
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+
+    def check_endpoints(self, *expected_statuses):
+        """
+        Check that various API endpoints return the expected status
+
+        We don't exhaustively test all endpoints, because auth is configured
+        globally for all endpoints using DEFAULT_AUTHENTICATION_CLASSES and
+        DEFAULT_PERMISSION_CLASSES. So we just test a few simple endpoints to
+        verify that those defaults are applied.
+        """
+        for url in self.basic_read_urls:
+            response = self.client.get(url)
+            self.assertIn(response.status_code, expected_statuses)
+        create_response = self.client.post('/api/v1/collections', data={'title': "Test Collection"})
+        self.assertIn(create_response.status_code, expected_statuses)
+
+    def test_unauthenticated_user_cannot_read(self):
+        """
+        Verify that an unauthenticated user cannot read from API endpoints
+        """
+        self.check_endpoints(status.HTTP_401_UNAUTHORIZED)
+
+    def test_regular_user_cannot_read(self):
+        """
+        Verify that an authenticated non-superuser cannot read from API endpoints
+        """
+        user = User.objects.create(username='test')
+        self.client.force_login(user)
+        self.check_endpoints(status.HTTP_403_FORBIDDEN)
+
+    def test_superuser_can_access(self):
+        """
+        Verify that a superuser account _can_ use the API
+        """
+        user = User.objects.create(username='super', is_superuser=True)
+        self.client.force_login(user)
+        self.check_endpoints(status.HTTP_200_OK, status.HTTP_201_CREATED)
+
+    def test_service_user_can_access(self):
+        """
+        Test that an external application's service user with a valid auth token
+        header can use the API.
+        """
+        test_user = User.objects.create(username='test-service-user')
+        token = Token.objects.create(user=test_user)
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
+        self.check_endpoints(status.HTTP_200_OK, status.HTTP_201_CREATED)

--- a/blockstore/settings/base.py
+++ b/blockstore/settings/base.py
@@ -40,9 +40,10 @@ INSTALLED_APPS = (
 
 THIRD_PARTY_APPS = (
     'rest_framework',
+    'rest_framework.authtoken',  # For authenticating API clients
     'rest_framework_swagger',
     'django_filters',
-    'social_django',
+    'social_django',  # To let admin users log in using their LMS user account
     'waffle',
     'corsheaders',
 )
@@ -100,6 +101,7 @@ DATABASES = {
 }
 
 
+################################################################################
 # Internationalization
 # https://docs.djangoproject.com/en/dev/topics/i18n/
 
@@ -118,6 +120,7 @@ LOCALE_PATHS = (
 )
 
 
+################################################################################
 # MEDIA CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#media-root
 MEDIA_ROOT = root('media')
@@ -127,6 +130,7 @@ MEDIA_URL = '/media/'
 # END MEDIA CONFIGURATION
 
 
+################################################################################
 # STATIC FILE CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#static-root
 STATIC_ROOT = root('assets')
@@ -137,6 +141,7 @@ STATIC_URL = '/static/'
 # See: https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#std:setting-STATICFILES_DIRS
 STATICFILES_DIRS = []
 
+################################################################################
 # TEMPLATE CONFIGURATION
 # See: https://docs.djangoproject.com/en/1.11/ref/settings/#templates
 TEMPLATES = [
@@ -164,6 +169,7 @@ TEMPLATES = [
 # END TEMPLATE CONFIGURATION
 
 
+################################################################################
 # COOKIE CONFIGURATION
 # The purpose of customizing the cookie names is to avoid conflicts when
 # multiple Django services are running behind the same hostname.
@@ -173,6 +179,7 @@ CSRF_COOKIE_NAME = 'blockstore_csrftoken'
 LANGUAGE_COOKIE_NAME = 'blockstore_language'
 # END COOKIE CONFIGURATION
 
+################################################################################
 # AUTHENTICATION CONFIGURATION
 LOGIN_URL = '/login/'
 LOGOUT_URL = '/logout/'
@@ -211,10 +218,32 @@ CORS_ORIGIN_REGEX_WHITELIST = (r'^(https?://)?localhost:.+$', )
 LOGIN_REDIRECT_URL = '/admin/'
 # END AUTHENTICATION CONFIGURATION
 
+################################################################################
+# REST FRAMEWORK CONFIGURATION
 
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        # We use token authentication to secure the API. We can't use OAuth2
+        # because django-oauth-toolkit is currently incompatible with utf8mb4
+        # (requires a small upstream fix to their DB migrations, to make the
+        # index length configurable like python-social-auth does.)
+        'rest_framework.authentication.TokenAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
+    ),
+    'DEFAULT_PERMISSION_CLASSES': (
+        # Only superusers or authorized applications that authenticate with a
+        # token are allowed to use the API.
+        'blockstore.apps.api.permissions.IsSuperUserOrAuthorizedApplication',
+    ),
+}
+
+################################################################################
 # OPENEDX-SPECIFIC CONFIGURATION
+
 PLATFORM_NAME = 'Your Platform Name Here'
-# END OPENEDX-SPECIFIC CONFIGURATION
+
+################################################################################
+# LOGGING CONFIGURATION
 
 hostname = platform.node().split(".")[0]
 

--- a/tagstore/tagstore_rest/v1/tests/test_views.py
+++ b/tagstore/tagstore_rest/v1/tests/test_views.py
@@ -1,12 +1,16 @@
 """ Tests for api v1 views. """
 from future.moves.urllib.parse import urlencode
 
+from django.contrib.auth import get_user_model
 from django.test import TestCase
+from rest_framework.authtoken.models import Token
 from rest_framework.reverse import reverse
 from rest_framework.test import APIClient
 
 from tagstore.backends.django import DjangoTagstore
 from tagstore.models import EntityId
+
+User = get_user_model()
 
 
 class ViewsBaseTestCase(TestCase):
@@ -17,6 +21,9 @@ class ViewsBaseTestCase(TestCase):
         super().setUp()
 
         self.client = APIClient()
+        test_user = User.objects.create(username='test-service-user')
+        token = Token.objects.create(user=test_user)
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
 
         self.tagstore = DjangoTagstore()
 


### PR DESCRIPTION
## Description

We want to ensure that even if the Blockstore REST API is accidentally exposed to the public internet, it will not accept any requests from unauthorized users/applications.

This PR restricts API access to:
* Users with superuser permission (so LMS admins can login via SSO and then use both the API and the django admin)
* Application service users that [authenticate with a valid token header](https://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication) - this is how the LMS will authenticate itself.

## Author Comments, Concerns, and Open Questions

Most Open edX IDAs use OAuth2 authentication; I tried using that initially but it turns out that django-oauth-toolkit is incompatible with the `utf8mb4` database encoding that Blockstore uses. Using a token header is simpler, faster, and perfectly secure, provided that the application is always served over HTTPS.

## Test Instructions

Login as a regular user then as a superuser and try to access http://localhost:18250/api/v1/
