### PR TITLE
Allow deleting draft via REST API

### DIFF
--- a/blockstore/apps/api/v1/tests/test_contract.py
+++ b/blockstore/apps/api/v1/tests/test_contract.py
@@ -389,6 +389,30 @@ class DraftsTest(ApiTestCase):
         )
         assert korea_text == "안녕하세요!"
 
+    def test_deleting_draft(self):
+        create_response = self.client.post(
+            '/api/v1/drafts',
+            {
+                'bundle_uuid': self.bundle_data['uuid'],
+                'name': 'temp_draft',
+                'title': "For DraftsTest.test_deleting_draft 😀",
+            }
+        )
+        create_data = response_data(create_response)
+        draft_url = create_data['url']
+
+        # Create some files so we're not just testing deletion of an empty draft...
+        self.client.patch(
+            draft_url,
+            data={'files': {'hawaii.txt': encode_str_for_draft("Aloha!")}},
+            format='json',
+        )
+        delete_response = self.client.delete(draft_url)
+        assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+        # Now confirm the draft is deleted
+        get_response = self.client.get(draft_url)
+        assert get_response.status_code == status.HTTP_404_NOT_FOUND
+
 
 def encode_str_for_draft(input_str):
     """Given a string, return UTF-8 representation that is then base64 encoded."""

--- a/blockstore/apps/api/v1/views/drafts.py
+++ b/blockstore/apps/api/v1/views/drafts.py
@@ -75,7 +75,7 @@ class DraftViewSet(viewsets.ModelViewSet):
     queryset = Draft.objects.all().select_related('bundle')
     lookup_field = 'uuid'
     page_size = 20
-    http_method_names = ['get', 'head', 'options', 'patch', 'post']
+    http_method_names = ['get', 'head', 'options', 'patch', 'post', 'delete']
 
     def get_serializer_class(self):
         """


### PR DESCRIPTION
## Description

Due to a minor oversight, it wasn't possible to delete a draft using the REST API.

## Test Instructions

Go to http://localhost:18250/api/v1/drafts and click on any draft. Notice the "Delete" button is missing (and if it was there it would raise an error). Check out this branch. Refresh. Now it's present and will work.
