### PR TITLE
Allow description to be blank when creating a bundle

### DIFF
--- a/blockstore/apps/api/v1/tests/test_contract.py
+++ b/blockstore/apps/api/v1/tests/test_contract.py
@@ -184,6 +184,18 @@ class BundlesMetadataTestCase(ApiTestCase):
         detail_data = response_data(detail_response)
         assert detail_data == create_data
 
+    def test_create_no_description(self):
+        """ Test that description is not required """
+        create_response = self.client.post(
+            '/api/v1/bundles',
+            data={
+                'collection_uuid': self.collection_uuid_str,
+                'slug': 'happy',
+                'title': "Happy Bundle 😀"
+            }
+        )
+        assert create_response.status_code == status.HTTP_201_CREATED
+
     def test_list(self):
         for i in range(10):
             self.client.post(

--- a/blockstore/apps/bundles/migrations/0001_initial.py
+++ b/blockstore/apps/bundles/migrations/0001_initial.py
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
                 ('uuid', models.UUIDField(default=uuid.uuid4, editable=False, unique=True)),
                 ('title', models.CharField(db_index=True, max_length=180)),
                 ('slug', models.SlugField(allow_unicode=True)),
-                ('description', models.TextField(max_length=10000)),
+                ('description', models.TextField(max_length=10000, blank=True)),
             ],
         ),
         migrations.CreateModel(

--- a/blockstore/apps/bundles/models.py
+++ b/blockstore/apps/bundles/models.py
@@ -96,7 +96,7 @@ class Bundle(models.Model):
     )
 
     slug = models.SlugField(allow_unicode=True)  # For pretty URLs
-    description = models.TextField(max_length=10000)
+    description = models.TextField(max_length=10000, blank=True)
 
     def __str__(self):
         return "Bundle {} - {}".format(self.uuid, self.slug)


### PR DESCRIPTION
## Description

Allow description to be blank when creating a bundle

## Author Comments, Concerns, and Open Questions

I assume we don't care if bundles have blank descriptions? I left slug as required.

If we want to insist on requiring descriptions, it's fine to close this PR.
