### PR TITLE
Fix: the API should only return absolute URLs

### DIFF
--- a/blockstore/apps/api/v1/serializers/bundles.py
+++ b/blockstore/apps/api/v1/serializers/bundles.py
@@ -128,6 +128,12 @@ class BundleVersionWithFileDataSerializer(BundleVersionSerializer):
                 "snapshot_digest": dependency.snapshot_digest.hex(),
             }
 
+        def _expand_url(self, url):
+            """Ensure that the given URL is an absolute URL"""
+            if not url.startswith('http'):
+                url = self.context['request'].build_absolute_uri(url)
+            return url
+
         def to_representation(self, value):
             """Snapshot JSON serialization."""
             snapshot = value
@@ -139,7 +145,7 @@ class BundleVersionWithFileDataSerializer(BundleVersionSerializer):
 
             info['files'] = {
                 path: {
-                    "url": snapshot_repo.url(snapshot, path),
+                    "url": self._expand_url(snapshot_repo.url(snapshot, path)),
                     "size": file_info.size,
                     "hash_digest": file_info.hash_digest.hex(),
                 }

--- a/blockstore/apps/api/v1/serializers/drafts.py
+++ b/blockstore/apps/api/v1/serializers/drafts.py
@@ -58,6 +58,12 @@ class DraftWithFileDataSerializer(DraftSerializer):
     class StagedDraftField(serializers.Field):
         """Read-only field for a StagedDraft."""
 
+        def _expand_url(self, url):
+            """Ensure that the given URL is an absolute URL"""
+            if not url.startswith('http'):
+                url = self.context['request'].build_absolute_uri(url)
+            return url
+
         def to_representation(self, value):
             """StagedDraft JSON serialization."""
             staged_draft = value
@@ -74,7 +80,7 @@ class DraftWithFileDataSerializer(DraftSerializer):
             }
             basic_info['files'] = {
                 path: {
-                    "url": draft_repo.url(staged_draft, path),
+                    "url": self._expand_url(draft_repo.url(staged_draft, path)),
                     "size": file_info.size,
                     "hash_digest": file_info.hash_digest.hex(),
                     "modified": path in staged_draft.files_to_overwrite

--- a/blockstore/apps/api/v1/tests/test_contract.py
+++ b/blockstore/apps/api/v1/tests/test_contract.py
@@ -298,6 +298,7 @@ class DraftsTest(ApiTestCase):
             self.client.get(bundle_detail_data['versions'][0])
         )
         file_url = bundle_version_detail_data['snapshot']['files']['hello.txt']['url']
+        assert file_url.startswith('http'), "Response URLs should be absolute"
         file_response = self.client.get(file_url)
         assert response_str_file(file_response) == "Hello World! 😀"
 


### PR DESCRIPTION
## Description

APIs returned by Blockstore [should](https://www.django-rest-framework.org/api-guide/reverse/) always be absolute, but currently the BundleVersion serializer sometimes returns relative URLs (if using local file media storage). This requires the client to be able to convert those to absolute URLs which is a pain.
