### PR TITLE
Fix: could not set unicode slugs via the REST API

### DIFF
--- a/blockstore/apps/api/v1/serializers/bundles.py
+++ b/blockstore/apps/api/v1/serializers/bundles.py
@@ -1,6 +1,7 @@
 """
 Serializers for Bundles and BundleVersions.
 """
+from django.core.validators import validate_unicode_slug
 from rest_framework import serializers
 from rest_framework.relations import SlugRelatedField
 from rest_framework.reverse import reverse
@@ -57,6 +58,9 @@ class BundleSerializer(serializers.ModelSerializer):
         slug_field='uuid',
         queryset=Collection.objects.all(),
     )
+
+    # DRF slug fields don't support unicode by default, so override it:
+    slug = serializers.CharField(validators=(validate_unicode_slug, ))
 
     url = relations.HyperlinkedIdentityField(
         lookup_field='uuid',

--- a/blockstore/apps/api/v1/tests/test_contract.py
+++ b/blockstore/apps/api/v1/tests/test_contract.py
@@ -163,7 +163,7 @@ class BundlesMetadataTestCase(ApiTestCase):
             data={
                 'collection_uuid': self.collection_uuid_str,
                 'description': "This is a 😀😀😀😀 Bundle",
-                'slug': 'happy',
+                'slug': 'Ηαρργ',  # Unicode slugs are allowed
                 'title': "Happy Bundle 😀"
             }
         )
@@ -173,7 +173,7 @@ class BundlesMetadataTestCase(ApiTestCase):
         assert create_data['collection_uuid'] == self.collection_uuid_str
         assert create_data['description'] == "This is a 😀😀😀😀 Bundle"
         assert create_data['drafts'] == {}
-        assert create_data['slug'] == 'happy'
+        assert create_data['slug'] == 'Ηαρργ'
         assert create_data['title'] == "Happy Bundle 😀"
         assert re.match(UUID4_REGEX, create_data['uuid'])
         assert create_data['url'] == u"http://testserver/api/v1/bundles/{}".format(create_data['uuid'])


### PR DESCRIPTION
## Description

The `slug` field has `allow_unicode=True`, but the DRF serializer was rejecting unicode characters if you tried to use the REST API to create a bundle with a unicode slug.

I know we may just remove the slug field altogether but this is an easy fix for now.
